### PR TITLE
Phase 1: data foundation + property detail UI overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,9 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# scratch files (screenshots, research, working docs)
+.scratch/
+
+# playwright MCP logs
+.playwright-mcp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,12 @@
 - There are no `.cursor`, `.cursorrules`, or `.github/copilot-instructions.md` files in the repo.
 - If such rules are added later, copy them verbatim into this section and mention their scope.
 
+## Agent Delegation
+- Proactively use `frontend-developer` and `ui-designer` subagents for any UI work — component creation, styling, layout fixes, responsive design, visual polish.
+- `ui-designer` for design review, visual hierarchy, color consistency, spacing, accessibility audits.
+- `frontend-developer` for writing/editing React components, Tailwind styling, state management, performance.
+- Dispatch both in parallel when creating new UI components (designer reviews while developer builds).
+
 ## Additional Notes
 - Use the `cn` helper (which wraps `clsx` + `twMerge`) whenever Tailwind lists branch on logic.
 - Keep shared UI elements inside `src/components/ui` and `src/components/layout` so variants stay consistent.

--- a/docs/plans/2026-02-20-phase1-data-foundation.md
+++ b/docs/plans/2026-02-20-phase1-data-foundation.md
@@ -1,0 +1,1188 @@
+# Phase 1: Data Foundation + Quick Wins — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add all Phase 1 data model fields (icons, tagline, highlights, specs, towers, config extensions, flexible POIs, parking) + quick frontend wins (sort, per-sqft display).
+
+**Architecture:** Sequential SQL migrations to add new tables/columns to Supabase PostgreSQL. TypeScript type updates. Admin form extensions using existing React Hook Form + shadcn/ui pattern. Public display sections on property detail page. No new API routes needed — everything flows through existing server actions.
+
+**Tech Stack:** Next.js 16, Supabase (PostgreSQL), TypeScript, React Hook Form, Zod, shadcn/ui, Lucide React
+
+---
+
+## Task 1: DB Migration — Icons Table + Seed Data
+
+**Files:**
+- Create: `supabase/migrations/00012_icons_table.sql`
+
+**Step 1: Write migration**
+
+```sql
+-- Icons table: reusable icon library for specs, highlights, etc.
+CREATE TABLE IF NOT EXISTS icons (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,              -- display name: "Flooring"
+  lucide_name TEXT NOT NULL,       -- lucide-react icon name: "layers"
+  category TEXT,                   -- grouping: "construction", "rooms", "general"
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- RLS: public read, admin write
+ALTER TABLE icons ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public can view icons"
+  ON icons FOR SELECT USING (true);
+
+CREATE POLICY "Admins can manage icons"
+  ON icons FOR ALL
+  USING (is_admin());
+
+-- Seed with real-estate-relevant Lucide icons
+INSERT INTO icons (name, lucide_name, category) VALUES
+  -- Construction & Materials
+  ('Flooring', 'layers', 'construction'),
+  ('Walls', 'square', 'construction'),
+  ('Paint', 'paintbrush', 'construction'),
+  ('Tiles', 'grid-3x3', 'construction'),
+  ('Cement', 'box', 'construction'),
+  ('Steel', 'shield', 'construction'),
+  ('Wood', 'tree-pine', 'construction'),
+  ('Glass', 'panel-top', 'construction'),
+  -- Rooms
+  ('Bedroom', 'bed-double', 'rooms'),
+  ('Bathroom', 'bath', 'rooms'),
+  ('Kitchen', 'cooking-pot', 'rooms'),
+  ('Living Room', 'sofa', 'rooms'),
+  ('Balcony', 'fence', 'rooms'),
+  ('Staircase', 'arrow-up-right', 'rooms'),
+  ('Parking', 'car', 'rooms'),
+  -- Fittings & Fixtures
+  ('Doors', 'door-open', 'fittings'),
+  ('Windows', 'app-window', 'fittings'),
+  ('Switches', 'toggle-right', 'fittings'),
+  ('Plumbing', 'droplets', 'fittings'),
+  ('Electrical', 'zap', 'fittings'),
+  ('AC', 'snowflake', 'fittings'),
+  ('Wardrobe', 'shirt', 'fittings'),
+  ('Chimney', 'wind', 'fittings'),
+  ('Sink', 'droplet', 'fittings'),
+  -- General
+  ('Elevator', 'arrow-up-down', 'general'),
+  ('Security', 'lock', 'general'),
+  ('Fire Safety', 'flame', 'general'),
+  ('Power', 'plug-zap', 'general'),
+  ('Water', 'waves', 'general'),
+  ('Garden', 'flower-2', 'general'),
+  ('View', 'eye', 'general'),
+  ('Location', 'map-pin', 'general'),
+  ('Quality', 'badge-check', 'general'),
+  ('Price', 'indian-rupee', 'general'),
+  ('Area', 'ruler', 'general'),
+  ('Building', 'building-2', 'general'),
+  ('Tower', 'building', 'general'),
+  ('Home', 'home', 'general'),
+  ('Star', 'star', 'general'),
+  ('Check', 'circle-check', 'general');
+```
+
+**Step 2: Apply migration**
+
+Run: `npx supabase db push` (or apply via Supabase dashboard)
+Expected: Table created, 40 icons seeded.
+
+**Step 3: Commit**
+
+```bash
+git add supabase/migrations/00012_icons_table.sql
+git commit -m "feat: add icons table with seed data for specs/highlights"
+```
+
+---
+
+## Task 2: DB Migration — Projects New Columns
+
+**Files:**
+- Create: `supabase/migrations/00013_project_new_fields.sql`
+
+Adds: `tagline`, `highlights`, `specifications`, `parking` to projects table.
+
+**Step 1: Write migration**
+
+```sql
+-- New project-level fields for Phase 1
+
+-- Tagline: short marketing line shown under project name
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS tagline TEXT;
+
+-- Highlights: ordered list of USPs [{text, icon_id}]
+-- Example: [{"text": "12 Ultra Luxury Sky-Villas", "icon_id": "uuid"}, ...]
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS highlights JSONB DEFAULT '[]'::jsonb;
+
+-- Specifications: key-value pairs with icons [{label, value, icon_id}]
+-- Example: [{"label": "Flooring", "value": "Premium Vitrified Tiles", "icon_id": "uuid"}, ...]
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS specifications JSONB DEFAULT '[]'::jsonb;
+
+-- Parking: structured parking info
+-- Example: {"types": ["stilt", "basement", "open"], "basement_levels": 2, "guest_parking": true, "allotment": "1 covered + 1 open per unit"}
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS parking JSONB;
+```
+
+**Step 2: Apply migration**
+
+Run: `npx supabase db push`
+Expected: 4 new columns on projects table.
+
+**Step 3: Commit**
+
+```bash
+git add supabase/migrations/00013_project_new_fields.sql
+git commit -m "feat: add tagline, highlights, specifications, parking columns to projects"
+```
+
+---
+
+## Task 3: DB Migration — Towers Table
+
+**Files:**
+- Create: `supabase/migrations/00014_towers_table.sql`
+
+**Step 1: Write migration**
+
+```sql
+-- Towers table: per-tower data for multi-tower projects
+CREATE TABLE IF NOT EXISTS towers (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,                -- "Tower A", "Wing B"
+  floor_from INT,                    -- starting floor number
+  floor_to INT,                      -- ending floor number
+  units_per_floor INT,               -- units on each floor
+  lifts_count INT,                   -- number of lifts
+  lift_type TEXT,                     -- "standard", "high-speed"
+  staircase_info TEXT,               -- e.g., "Double staircase"
+  sort_order INT DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_towers_project_id ON towers(project_id);
+
+-- RLS
+ALTER TABLE towers ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public can view towers"
+  ON towers FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM projects
+      WHERE projects.id = towers.project_id
+        AND projects.published_at IS NOT NULL
+        AND projects.deleted_at IS NULL
+    )
+  );
+
+CREATE POLICY "Admins can manage towers"
+  ON towers FOR ALL
+  USING (is_admin());
+
+-- Grant anon SELECT
+GRANT SELECT ON towers TO anon;
+GRANT ALL ON towers TO authenticated;
+```
+
+**Step 2: Apply migration**
+
+Run: `npx supabase db push`
+Expected: towers table created with RLS.
+
+**Step 3: Commit**
+
+```bash
+git add supabase/migrations/00014_towers_table.sql
+git commit -m "feat: add towers table for per-tower project data"
+```
+
+---
+
+## Task 4: DB Migration — Configurations Extensions
+
+**Files:**
+- Create: `supabase/migrations/00015_configurations_extensions.sql`
+
+Adds: area fields, tower FK, floor range, type label.
+
+**Step 1: Write migration**
+
+```sql
+-- Extended area fields
+ALTER TABLE configurations ADD COLUMN IF NOT EXISTS balcony_area_sqft INT;
+ALTER TABLE configurations ADD COLUMN IF NOT EXISTS covered_area_sqft INT;
+ALTER TABLE configurations ADD COLUMN IF NOT EXISTS super_area_sqft INT;
+
+-- Tower association
+ALTER TABLE configurations ADD COLUMN IF NOT EXISTS tower_id UUID REFERENCES towers(id) ON DELETE SET NULL;
+
+-- Floor range
+ALTER TABLE configurations ADD COLUMN IF NOT EXISTS floor_from INT;
+ALTER TABLE configurations ADD COLUMN IF NOT EXISTS floor_to INT;
+
+-- Type label (e.g., "Type A", "Type B")
+ALTER TABLE configurations ADD COLUMN IF NOT EXISTS type_label TEXT;
+
+CREATE INDEX idx_configurations_tower_id ON configurations(tower_id);
+```
+
+**Step 2: Apply migration**
+
+Run: `npx supabase db push`
+Expected: 6 new columns on configurations table.
+
+**Step 3: Commit**
+
+```bash
+git add supabase/migrations/00015_configurations_extensions.sql
+git commit -m "feat: extend configurations with area fields, tower FK, floor range"
+```
+
+---
+
+## Task 5: DB Migration — Flexible POIs
+
+**Files:**
+- Create: `supabase/migrations/00016_flexible_pois.sql`
+
+Replaces the hardcoded 5-key `location_advantages` JSONB with a flexible `points_of_interest` JSONB array. Keeps the old column for backward compat during transition.
+
+**Step 1: Write migration**
+
+```sql
+-- Flexible points of interest array
+-- Example: [{"name": "Elante Mall", "category": "shopping", "distance_value": 5.5, "distance_unit": "km"}, ...]
+-- Categories: transport, education, healthcare, shopping, food, lifestyle, notable
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS points_of_interest JSONB DEFAULT '[]'::jsonb;
+```
+
+**Step 2: Apply migration**
+
+Run: `npx supabase db push`
+Expected: New column on projects table. Old `location_advantages` column still exists (will migrate data later).
+
+**Step 3: Commit**
+
+```bash
+git add supabase/migrations/00016_flexible_pois.sql
+git commit -m "feat: add flexible points_of_interest JSONB column"
+```
+
+---
+
+## Task 6: Update TypeScript Types
+
+**Files:**
+- Modify: `src/types/database.ts`
+
+**Step 1: Add new types and update interfaces**
+
+Add these new interfaces and update existing ones:
+
+```typescript
+// New interfaces to add:
+
+export interface Icon {
+  id: string;
+  name: string;
+  lucide_name: string;
+  category: string | null;
+}
+
+export interface Tower {
+  id: string;
+  project_id: string;
+  name: string;
+  floor_from: number | null;
+  floor_to: number | null;
+  units_per_floor: number | null;
+  lifts_count: number | null;
+  lift_type: string | null;
+  staircase_info: string | null;
+  sort_order: number;
+}
+
+export interface ProjectHighlight {
+  text: string;
+  icon_id: string | null;
+}
+
+export interface ProjectSpecification {
+  label: string;
+  value: string;
+  icon_id: string | null;
+}
+
+export interface ProjectParking {
+  types: string[];           // ["stilt", "basement", "open", "covered"]
+  basement_levels: number | null;
+  guest_parking: boolean;
+  allotment: string | null;  // "1 covered + 1 open per unit"
+}
+
+export interface PointOfInterest {
+  name: string;
+  category: string;  // "transport" | "education" | "healthcare" | "shopping" | "food" | "lifestyle" | "notable"
+  distance_value: number;
+  distance_unit: string;  // "km" | "min"
+}
+```
+
+Update `Project` interface — add these fields:
+```typescript
+  tagline: string | null;
+  highlights: ProjectHighlight[];
+  specifications: ProjectSpecification[];
+  parking: ProjectParking | null;
+  points_of_interest: PointOfInterest[];
+  // Joined relations (add):
+  towers?: Tower[];
+```
+
+Update `Configuration` interface — add these fields:
+```typescript
+  balcony_area_sqft: number | null;
+  covered_area_sqft: number | null;
+  super_area_sqft: number | null;
+  tower_id: string | null;
+  floor_from: number | null;
+  floor_to: number | null;
+  type_label: string | null;
+  // Joined relation:
+  tower?: Tower;
+```
+
+Add to `ProjectFilters`:
+```typescript
+  sort?: "price_asc" | "price_desc" | "newest" | "possession";
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/types/database.ts
+git commit -m "feat: update TS types for phase 1 fields"
+```
+
+---
+
+## Task 7: Update Supabase Queries
+
+**Files:**
+- Modify: `src/lib/queries/projects.ts`
+
+**Step 1: Add towers to project select + add sort support**
+
+In `getProjects()`:
+- Add `towers(*)` to the select join
+- Add sort logic based on `filters.sort`
+- Map towers in the transform
+
+In `getProjectBySlug()`:
+- Add `towers(*)` to the select join
+- Map towers in the transform
+
+Add new query:
+```typescript
+export async function getIcons(): Promise<Icon[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("icons")
+    .select("*")
+    .order("category", { ascending: true })
+    .order("name", { ascending: true });
+
+  if (error) {
+    console.error("Error fetching icons:", error);
+    return [];
+  }
+  return data || [];
+}
+```
+
+For sort, replace the hardcoded `.order("created_at", { ascending: false })` with:
+```typescript
+// Sort
+switch (filters?.sort) {
+  case "price_asc":
+    query = query.order("price_min", { ascending: true, nullsFirst: false });
+    break;
+  case "price_desc":
+    query = query.order("price_min", { ascending: false });
+    break;
+  case "possession":
+    query = query.order("possession_date", { ascending: true, nullsFirst: false });
+    break;
+  case "newest":
+  default:
+    query = query.order("created_at", { ascending: false });
+    break;
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/lib/queries/projects.ts
+git commit -m "feat: add towers join, sort support, icons query"
+```
+
+---
+
+## Task 8: Admin — Property Form Schema Update
+
+**Files:**
+- Modify: `src/app/admin/properties/_components/property-schema.ts`
+
+**Step 1: Add tagline to Zod schema**
+
+Add to `propertyFormSchema`:
+```typescript
+tagline: z.string().optional(),
+```
+
+Add to `PropertyFormData` interface:
+```typescript
+tagline?: string;
+highlights: ProjectHighlight[];
+specifications: ProjectSpecification[];
+parking: ProjectParking | null;
+towers: Partial<Tower>[];
+points_of_interest: PointOfInterest[];
+```
+
+Update `transformFormData` to include new fields (passed through as separate state, same pattern as images/configs/amenityIds).
+
+Update `projectToFormValues` to hydrate new fields from project data.
+
+**Step 2: Commit**
+
+```bash
+git add src/app/admin/properties/_components/property-schema.ts
+git commit -m "feat: update property form schema for phase 1 fields"
+```
+
+---
+
+## Task 9: Admin — HighlightsEditor Component
+
+**Files:**
+- Create: `src/app/admin/properties/_components/HighlightsEditor.tsx`
+
+**Step 1: Build component**
+
+Pattern matches existing `ConfigurationsEditor.tsx`. Repeater with text input + icon selector dropdown.
+
+```typescript
+// Props:
+interface HighlightsEditorProps {
+  highlights: ProjectHighlight[];
+  icons: Icon[];
+  onChange: (highlights: ProjectHighlight[]) => void;
+}
+```
+
+Each row: text input + icon select dropdown (from icons table) + remove button.
+Add button at bottom.
+
+**Step 2: Commit**
+
+```bash
+git add src/app/admin/properties/_components/HighlightsEditor.tsx
+git commit -m "feat: add HighlightsEditor admin component"
+```
+
+---
+
+## Task 10: Admin — SpecificationsEditor Component
+
+**Files:**
+- Create: `src/app/admin/properties/_components/SpecificationsEditor.tsx`
+
+**Step 1: Build component**
+
+Same repeater pattern. Each row: label input + value input + icon select + remove button.
+
+```typescript
+interface SpecificationsEditorProps {
+  specifications: ProjectSpecification[];
+  icons: Icon[];
+  onChange: (specs: ProjectSpecification[]) => void;
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/app/admin/properties/_components/SpecificationsEditor.tsx
+git commit -m "feat: add SpecificationsEditor admin component"
+```
+
+---
+
+## Task 11: Admin — ParkingEditor Component
+
+**Files:**
+- Create: `src/app/admin/properties/_components/ParkingEditor.tsx`
+
+**Step 1: Build component**
+
+Checkbox group for parking types + number input for basement levels + checkbox for guest parking + text input for allotment description.
+
+```typescript
+interface ParkingEditorProps {
+  parking: ProjectParking | null;
+  onChange: (parking: ProjectParking | null) => void;
+}
+```
+
+Parking type options: `["stilt", "basement", "open", "covered", "multi-level"]`
+
+**Step 2: Commit**
+
+```bash
+git add src/app/admin/properties/_components/ParkingEditor.tsx
+git commit -m "feat: add ParkingEditor admin component"
+```
+
+---
+
+## Task 12: Admin — TowersEditor Component
+
+**Files:**
+- Create: `src/app/admin/properties/_components/TowersEditor.tsx`
+
+**Step 1: Build component**
+
+Repeater pattern. Each tower row: name, floor_from, floor_to, units_per_floor, lifts_count, lift_type select, staircase_info text.
+
+```typescript
+interface TowersEditorProps {
+  towers: Partial<Tower>[];
+  onChange: (towers: Partial<Tower>[]) => void;
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/app/admin/properties/_components/TowersEditor.tsx
+git commit -m "feat: add TowersEditor admin component"
+```
+
+---
+
+## Task 13: Admin — POIsEditor Component
+
+**Files:**
+- Create: `src/app/admin/properties/_components/POIsEditor.tsx`
+
+**Step 1: Build component**
+
+Repeater with: name text input, category select, distance_value number, distance_unit select (km/min).
+
+Later phase: will add Google Places API autocomplete. For now, manual entry.
+
+```typescript
+interface POIsEditorProps {
+  pois: PointOfInterest[];
+  onChange: (pois: PointOfInterest[]) => void;
+}
+```
+
+Category options: `["transport", "education", "healthcare", "shopping", "food", "lifestyle", "notable"]`
+
+**Step 2: Commit**
+
+```bash
+git add src/app/admin/properties/_components/POIsEditor.tsx
+git commit -m "feat: add POIsEditor admin component"
+```
+
+---
+
+## Task 14: Admin — Update ConfigurationsEditor
+
+**Files:**
+- Modify: `src/app/admin/properties/_components/ConfigurationsEditor.tsx`
+
+**Step 1: Add new fields to each config row**
+
+Add to the grid in each config row:
+- `balcony_area_sqft` — number input, label "Balcony Area (sqft)"
+- `covered_area_sqft` — number input, label "Covered Area (sqft)"
+- `super_area_sqft` — number input, label "Super Area (sqft)"
+- `tower_id` — select dropdown (requires towers list as prop)
+- `floor_from` — number input
+- `floor_to` — number input
+- `type_label` — text input, placeholder "Type A"
+
+Update props to accept towers list:
+```typescript
+interface ConfigurationsEditorProps {
+  configurations: Partial<Configuration>[];
+  towers: Partial<Tower>[];
+  onChange: (configs: Partial<Configuration>[]) => void;
+}
+```
+
+Update `addConfig` default to include new null fields.
+
+**Step 2: Commit**
+
+```bash
+git add src/app/admin/properties/_components/ConfigurationsEditor.tsx
+git commit -m "feat: extend ConfigurationsEditor with area fields, tower, floor range"
+```
+
+---
+
+## Task 15: Admin — Wire Everything into PropertyForm
+
+**Files:**
+- Modify: `src/app/admin/properties/_components/PropertyForm.tsx`
+
+**Step 1: Add imports and state for new editors**
+
+Add state variables (same pattern as images/configs/amenityIds):
+```typescript
+const [highlights, setHighlights] = useState<ProjectHighlight[]>(initialData?.highlights || []);
+const [specifications, setSpecifications] = useState<ProjectSpecification[]>(initialData?.specifications || []);
+const [parking, setParking] = useState<ProjectParking | null>(initialData?.parking || null);
+const [towers, setTowers] = useState<Partial<Tower>[]>(initialData?.towers || []);
+const [pois, setPois] = useState<PointOfInterest[]>(initialData?.points_of_interest || []);
+```
+
+**Step 2: Add tagline field to Basic Info card**
+
+After description textarea:
+```tsx
+<div className="space-y-2 sm:col-span-2">
+  <Label htmlFor="tagline">Tagline</Label>
+  <Input id="tagline" {...form.register("tagline")} placeholder="Short marketing line, e.g., 'Gateway of Chandigarh'" maxLength={100} />
+</div>
+```
+
+**Step 3: Add new Card sections**
+
+After Amenities card, add new cards for: Highlights, Specifications, Towers, Parking, Points of Interest. Each card wraps the corresponding editor component.
+
+**Step 4: Update handleSubmit**
+
+Pass new state to `transformFormData`:
+```typescript
+const fullData = transformFormData(data, images, configurations, amenityIds, highlights, specifications, parking, towers, pois);
+```
+
+**Step 5: Update PropertyFormProps to accept icons**
+
+```typescript
+interface PropertyFormProps {
+  // ... existing props
+  icons: Icon[];
+}
+```
+
+**Step 6: Commit**
+
+```bash
+git add src/app/admin/properties/_components/PropertyForm.tsx
+git commit -m "feat: wire phase 1 editors into PropertyForm"
+```
+
+---
+
+## Task 16: Admin — Update Server Actions
+
+**Files:**
+- Modify: `src/app/admin/properties/actions.ts`
+
+**Step 1: Save new project-level fields**
+
+In both `createPropertyAction` and `updatePropertyAction`, add to the insert/update object:
+```typescript
+tagline: data.tagline || null,
+highlights: data.highlights || [],
+specifications: data.specifications || [],
+parking: data.parking || null,
+points_of_interest: data.points_of_interest || [],
+```
+
+**Step 2: Save towers (create action)**
+
+After inserting the project, insert towers:
+```typescript
+if (data.towers.length > 0) {
+  const towersToInsert = data.towers.map((tower, index) => ({
+    project_id: projectId,
+    name: tower.name!,
+    floor_from: tower.floor_from ?? null,
+    floor_to: tower.floor_to ?? null,
+    units_per_floor: tower.units_per_floor ?? null,
+    lifts_count: tower.lifts_count ?? null,
+    lift_type: tower.lift_type || null,
+    staircase_info: tower.staircase_info || null,
+    sort_order: index,
+  }));
+
+  const { error: towersError } = await supabase
+    .from("towers")
+    .insert(towersToInsert);
+
+  if (towersError) console.error("Error inserting towers:", towersError);
+}
+```
+
+**Step 3: Save towers (update action)**
+
+Same delete-then-insert pattern as configs:
+```typescript
+await supabase.from("towers").delete().eq("project_id", id);
+// Then insert same as above
+```
+
+**Step 4: Update configs insert to include new fields**
+
+In both create and update, add to configsToInsert map:
+```typescript
+balcony_area_sqft: config.balcony_area_sqft ?? null,
+covered_area_sqft: config.covered_area_sqft ?? null,
+super_area_sqft: config.super_area_sqft ?? null,
+tower_id: config.tower_id || null,
+floor_from: config.floor_from ?? null,
+floor_to: config.floor_to ?? null,
+type_label: config.type_label || null,
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/app/admin/properties/actions.ts
+git commit -m "feat: save phase 1 fields in create/update actions"
+```
+
+---
+
+## Task 17: Admin — Pass Icons + Towers to Form Pages
+
+**Files:**
+- Modify: `src/app/admin/properties/new/page.tsx`
+- Modify: `src/app/admin/properties/[id]/page.tsx`
+
+**Step 1: Fetch icons in both pages**
+
+Import and call `getIcons()` alongside existing data fetching (builders, cities, amenities). Pass `icons` prop to `PropertyForm`.
+
+For the edit page, also fetch towers for the project and pass them as part of initialData.
+
+**Step 2: Commit**
+
+```bash
+git add src/app/admin/properties/new/page.tsx src/app/admin/properties/\[id\]/page.tsx
+git commit -m "feat: pass icons and towers data to admin property form"
+```
+
+---
+
+## Task 18: Public — Sort Dropdown on Listings
+
+**Files:**
+- Modify: `src/app/(main)/properties/page.tsx`
+- Create: `src/components/property/SortDropdown.tsx`
+
+**Step 1: Build SortDropdown component**
+
+Client component. Reads current `sort` from URL params, updates URL on change.
+
+```typescript
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+const SORT_OPTIONS = [
+  { value: "", label: "Newest First" },
+  { value: "price_asc", label: "Price: Low to High" },
+  { value: "price_desc", label: "Price: High to Low" },
+  { value: "possession", label: "Possession Date" },
+];
+```
+
+Renders a `<select>` styled with shadcn classes. On change, updates `?sort=` search param.
+
+**Step 2: Add to listings page**
+
+In `PropertiesContent`, pass `params.sort` to `getProjects(filters)`.
+Add `<SortDropdown />` next to the property count text.
+
+**Step 3: Commit**
+
+```bash
+git add src/components/property/SortDropdown.tsx src/app/\(main\)/properties/page.tsx
+git commit -m "feat: add sort dropdown to listings page"
+```
+
+---
+
+## Task 19: Public — Per Sq Ft Price on Cards + Detail
+
+**Files:**
+- Modify: `src/app/(main)/properties/[slug]/page.tsx` (detail page quick info)
+- Find and modify: property card component (likely `src/components/property/PropertyCard.tsx` or inside `PropertyGrid.tsx`)
+
+**Step 1: Add per-sqft to Quick Info card on detail page**
+
+In the Quick Info grid (4-column), either add a 5th item or replace the "Units" column when not available. Show `price_per_sqft` formatted as "X/sqft".
+
+```tsx
+{project.price_per_sqft && (
+  <div>
+    <p className="text-sm text-gray-500">Price / Sq Ft</p>
+    <p className="font-semibold">{formatPrice(project.price_per_sqft)}/sqft</p>
+  </div>
+)}
+```
+
+**Step 2: Add per-sqft to property cards**
+
+Show below price range if available.
+
+**Step 3: Commit**
+
+```bash
+git add src/app/\(main\)/properties/\[slug\]/page.tsx src/components/property/PropertyCard.tsx
+git commit -m "feat: display per-sqft price on cards and detail page"
+```
+
+---
+
+## Task 20: Public — Highlights Section on Detail Page
+
+**Files:**
+- Modify: `src/app/(main)/properties/[slug]/page.tsx`
+
+**Step 1: Add Highlights section**
+
+After the Quick Info card, before Location. Only render if `project.highlights?.length > 0`.
+
+Display as a grid of cards, each with icon (from Lucide by looking up icon name) + text.
+
+Note: Need to join icons data or store `lucide_name` directly in the highlight. Simplest approach: store `icon_id` in highlight, fetch icons in the page query, and look up the lucide name. Alternatively, denormalize and store `lucide_name` directly in the JSONB.
+
+**Decision: denormalize** — store `icon_id` AND `icon_name` (lucide_name) in the JSONB highlight objects. The admin form populates both from the icons dropdown. This avoids a join on the public page.
+
+Update `ProjectHighlight` type:
+```typescript
+export interface ProjectHighlight {
+  text: string;
+  icon_id: string | null;
+  icon_name: string | null;  // lucide_name, denormalized
+}
+```
+
+Then render:
+```tsx
+{project.highlights?.length > 0 && (
+  <Card>
+    <CardHeader>
+      <CardTitle>Project Highlights</CardTitle>
+    </CardHeader>
+    <CardContent>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {project.highlights.map((h, i) => (
+          <div key={i} className="flex items-start gap-3 p-3 rounded-lg bg-gray-50">
+            {/* Render Lucide icon dynamically */}
+            <span className="text-primary">{/* icon */}</span>
+            <span>{h.text}</span>
+          </div>
+        ))}
+      </div>
+    </CardContent>
+  </Card>
+)}
+```
+
+For dynamic Lucide icon rendering, create a small helper component `DynamicIcon`:
+```typescript
+// src/components/ui/DynamicIcon.tsx
+import { icons } from "lucide-react";
+
+export function DynamicIcon({ name, ...props }: { name: string } & React.SVGProps<SVGSVGElement>) {
+  const Icon = icons[name as keyof typeof icons];
+  if (!Icon) return null;
+  return <Icon {...props} />;
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/components/ui/DynamicIcon.tsx src/app/\(main\)/properties/\[slug\]/page.tsx
+git commit -m "feat: display project highlights on detail page"
+```
+
+---
+
+## Task 21: Public — Specifications Section on Detail Page
+
+**Files:**
+- Modify: `src/app/(main)/properties/[slug]/page.tsx`
+
+**Step 1: Add Specifications section**
+
+After Highlights. Same denormalization approach for icon names.
+
+Render as a two-column table: icon + label | value.
+
+```tsx
+{project.specifications?.length > 0 && (
+  <Card>
+    <CardHeader>
+      <CardTitle>Specifications</CardTitle>
+    </CardHeader>
+    <CardContent>
+      <div className="divide-y">
+        {project.specifications.map((spec, i) => (
+          <div key={i} className="flex items-center justify-between py-3">
+            <div className="flex items-center gap-2 text-gray-600">
+              <DynamicIcon name={spec.icon_name || "circle"} className="w-4 h-4" />
+              <span>{spec.label}</span>
+            </div>
+            <span className="font-medium">{spec.value}</span>
+          </div>
+        ))}
+      </div>
+    </CardContent>
+  </Card>
+)}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/app/\(main\)/properties/\[slug\]/page.tsx
+git commit -m "feat: display specifications on detail page"
+```
+
+---
+
+## Task 22: Public — Towers Section on Detail Page
+
+**Files:**
+- Modify: `src/app/(main)/properties/[slug]/page.tsx`
+
+**Step 1: Add Towers section**
+
+After Project Details card. Render tower cards in a grid.
+
+```tsx
+{project.towers?.length > 0 && (
+  <Card>
+    <CardHeader>
+      <CardTitle>Tower Details</CardTitle>
+    </CardHeader>
+    <CardContent>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {project.towers.map((tower) => (
+          <div key={tower.id} className="p-4 rounded-lg border bg-gray-50">
+            <h4 className="font-semibold mb-2">{tower.name}</h4>
+            <div className="space-y-1 text-sm text-gray-600">
+              {tower.floor_from != null && tower.floor_to != null && (
+                <p>Floors: {tower.floor_from} to {tower.floor_to}</p>
+              )}
+              {tower.units_per_floor && <p>{tower.units_per_floor} units per floor</p>}
+              {tower.lifts_count && <p>{tower.lifts_count} {tower.lift_type || ""} lifts</p>}
+              {tower.staircase_info && <p>{tower.staircase_info}</p>}
+            </div>
+          </div>
+        ))}
+      </div>
+    </CardContent>
+  </Card>
+)}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/app/\(main\)/properties/\[slug\]/page.tsx
+git commit -m "feat: display tower details on detail page"
+```
+
+---
+
+## Task 23: Public — Enhanced Configurations Table
+
+**Files:**
+- Modify: `src/app/(main)/properties/[slug]/page.tsx`
+
+**Step 1: Expand configs table**
+
+Update the configurations table to show:
+- Type label (if present)
+- Config name / BHK
+- Tower name (if tower_id linked)
+- Floor range
+- Carpet area (existing)
+- Super area (if available)
+- Price (existing)
+
+Add columns to the `<table>` for the new fields. Only show columns if at least one config has data for them.
+
+**Step 2: Commit**
+
+```bash
+git add src/app/\(main\)/properties/\[slug\]/page.tsx
+git commit -m "feat: enhance configurations table with area fields, tower, floor range"
+```
+
+---
+
+## Task 24: Public — Parking Section on Detail Page
+
+**Files:**
+- Modify: `src/app/(main)/properties/[slug]/page.tsx`
+
+**Step 1: Add Parking section**
+
+After Towers, before Amenities. Only render if `project.parking` is not null.
+
+```tsx
+{project.parking && (
+  <Card>
+    <CardHeader>
+      <CardTitle className="flex items-center gap-2">
+        <Car className="w-5 h-5" />
+        Parking
+      </CardTitle>
+    </CardHeader>
+    <CardContent>
+      <div className="grid grid-cols-2 gap-4">
+        {project.parking.types?.length > 0 && (
+          <div>
+            <p className="text-sm text-gray-500">Parking Types</p>
+            <p className="font-medium capitalize">{project.parking.types.join(", ")}</p>
+          </div>
+        )}
+        {project.parking.basement_levels && (
+          <div>
+            <p className="text-sm text-gray-500">Basement Levels</p>
+            <p className="font-medium">{project.parking.basement_levels}</p>
+          </div>
+        )}
+        <div>
+          <p className="text-sm text-gray-500">Guest Parking</p>
+          <p className="font-medium">{project.parking.guest_parking ? "Yes" : "No"}</p>
+        </div>
+        {project.parking.allotment && (
+          <div>
+            <p className="text-sm text-gray-500">Per Unit Allotment</p>
+            <p className="font-medium">{project.parking.allotment}</p>
+          </div>
+        )}
+      </div>
+    </CardContent>
+  </Card>
+)}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/app/\(main\)/properties/\[slug\]/page.tsx
+git commit -m "feat: display parking details on detail page"
+```
+
+---
+
+## Task 25: Public — Flexible POIs Section on Detail Page
+
+**Files:**
+- Create: `src/components/property/PointsOfInterest.tsx`
+- Modify: `src/app/(main)/properties/[slug]/page.tsx`
+
+**Step 1: Build POIs component**
+
+Category-based tabs or toggles showing nearby places with distances. Replace or augment existing `LocationAdvantages` component.
+
+```typescript
+interface PointsOfInterestProps {
+  pois: PointOfInterest[];
+}
+```
+
+Group POIs by category. Show category toggle buttons at top. List matching POIs with distance badges.
+
+**Step 2: Wire into detail page**
+
+Replace the `LocationAdvantages` section with the new `PointsOfInterest` when `points_of_interest` has data. Fall back to old `LocationAdvantages` when only old data exists.
+
+**Step 3: Commit**
+
+```bash
+git add src/components/property/PointsOfInterest.tsx src/app/\(main\)/properties/\[slug\]/page.tsx
+git commit -m "feat: display flexible POIs with category tabs on detail page"
+```
+
+---
+
+## Task 26: Verify Build + Final Commit
+
+**Step 1: Run build**
+
+```bash
+npm run build
+```
+
+Fix any TypeScript errors.
+
+**Step 2: Manual verification**
+
+- Visit admin /properties/new — verify all new form sections render
+- Create a test property with highlights, specs, towers, parking, POIs
+- Visit the public detail page — verify all new sections display
+- Visit listings page — verify sort dropdown works
+- Verify per-sqft shows on cards
+
+**Step 3: Final commit if any fixes needed**
+
+```bash
+git add -A
+git commit -m "fix: resolve build issues from phase 1"
+```
+
+---
+
+## Dependency Graph
+
+```
+Task 1 (icons) ─────────────────────────────────┐
+Task 2 (project cols) ──────────────────────────┤
+Task 3 (towers) ─────┬──────────────────────────┤
+Task 4 (config ext) ──┘                         ├─ Task 6 (types) ─── Task 7-8 (schema + admin components)
+Task 5 (POIs) ───────────────────────────────────┘         │
+                                                           ├─ Tasks 9-14 (admin editors)
+                                                           ├─ Task 15 (wire form)
+                                                           ├─ Task 16 (actions)
+                                                           ├─ Task 17 (pass data)
+                                                           └─ Tasks 18-25 (public display)
+                                                                    │
+                                                              Task 26 (verify)
+```
+
+**Parallelizable groups:**
+- Tasks 1-5 (migrations) — independent, can all run in one batch
+- Tasks 9-14 (admin editor components) — independent of each other
+- Tasks 18-25 (public display sections) — mostly independent of each other
+
+---
+
+## Unresolved Questions
+
+1. DynamicIcon: `lucide-react` `icons` object may increase bundle size if tree-shaking fails — verify or use lazy import?
+2. Denormalize icon_name in highlights/specs JSONB or join at query time?
+  - Plan assumes denormalize (simpler, no join). Tradeoff: icon rename requires data migration

--- a/docs/plans/2026-02-20-platform-gaps-roadmap.md
+++ b/docs/plans/2026-02-20-platform-gaps-roadmap.md
@@ -1,0 +1,314 @@
+
+# Platform Gaps Roadmap
+**Date:** 2026-02-20
+**Sources:** Truva competitive analysis, Northview Homez brochure gap analysis
+**Context:** PerfectGhar deals with full builder projects (multi-tower, multi-config), not single-unit resales like Truva. Roadmap accounts for this.
+
+---
+
+## How This Is Organized
+
+Gaps from both analyses are deduplicated and merged into a single list, then grouped into 5 phases. Each phase is roughly a sprint. Phase 1 has the highest impact-to-effort ratio.
+
+Legend: `[T]` = from Truva analysis, `[B]` = from brochure analysis, `[TB]` = both
+
+---
+
+## Phase 1 — Data Foundation + Quick Wins
+
+These are either pure data-model additions (unlock richer listings) or trivial frontend wins. Do these first because everything downstream depends on having the data.
+
+### 1.1 Project Highlights / USPs `[TB]`
+- **What:** Repeatable ordered list of punchy selling points per project
+- **Why:** Both Truva ("Top reasons to love this home") and brochures ("12 Ultra Luxury Sky-Villas") rely on this heavily. Currently only freeform `description`
+- **Work:** Add `highlights` JSONB array to projects table. Admin form: repeater input. Detail page: icon + text cards section
+- **Effort:** Small
+
+### 1.2 Tagline / Subtitle `[B]`
+- **What:** Short marketing line (~100 chars) displayed under project name
+- **Why:** Every brochure has taglines ("Gateway of Chandigarh"). Cards and hero look flat without one
+- **Work:** Add `tagline` text field to projects table. Show on cards + detail hero
+- **Effort:** Tiny
+
+### 1.3 Per Sq Ft Price Display `[T]`
+- **What:** Show price/sqft on cards and detail page
+- **Why:** Standard comparison metric in Indian RE. Field `price_per_sqft` already exists in DB
+- **Work:** Frontend-only — display existing field on property cards + detail page. Auto-calc from config data if not manually set
+- **Effort:** Tiny
+
+### 1.4 Floor Plan Area Breakdown `[B]`
+- **What:** Add balcony_area_sqft, covered_area_sqft, super_area_sqft to configurations
+- **Why:** Brochures always show 4 area types. Buyers expect this. We only store carpet + built-up
+- **Work:** DB migration + admin form fields + detail page display
+- **Effort:** Small
+
+### 1.5 Tower-Level Data Model `[B]`
+- **What:** `towers` table — name, floor_count, floor_range, units_per_floor, lifts, staircase info
+- **Why:** Multi-tower projects are our bread and butter. Can't represent "Tower A: floors 1-7, 2 units/floor" today
+- **Work:** New table + admin UI for tower CRUD + link configs to towers
+- **Effort:** Medium
+
+### 1.6 Config-to-Tower + Floor Mapping `[B]`
+- **What:** Link each configuration to tower(s) + floor range + type label
+- **Why:** "3BHK Type A, Tower A&B, Floors 1-7" is how buyers think. Depends on 1.5
+- **Work:** FK or M2M to towers, floor_from/floor_to, type_label fields on configs
+- **Effort:** Small (after 1.5)
+
+### 1.7 Technical Specifications `[B]`
+- **What:** Room-by-room material specs (flooring, fittings, fixtures, provisions)
+- **Why:** Every brochure has a full page of specs. Zero fields for this today. Serious buyers care deeply
+- **Work:** `specifications` JSONB on projects — keyed by room category. Admin: nested form. Detail page: collapsible table
+- **Effort:** Medium
+
+### 1.8 Sort Options on Listings `[T]`
+- **What:** Sort dropdown: Price low-high, high-low, newest, possession date
+- **Why:** Trivial to implement, huge usability gap. Every property portal has this
+- **Work:** Frontend dropdown + Supabase order_by param
+- **Effort:** Tiny
+
+### 1.9 Flexible Proximity / POIs `[TB]`
+- **What:** Replace hardcoded 5-key location_advantages with flexible array of {name, category, distance, unit}
+- **Why:** Truva shows categorized nearby places with distances. Brochures list 8+ landmarks. Current hardcoded keys are limiting
+- **Work:** DB migration (new JSONB structure or related table), admin repeater, detail page with category tabs + map markers
+- **Effort:** Medium
+
+### 1.10 Parking Details `[B]`
+- **What:** Parking types (stilt, basement, open, covered), basement levels, guest parking, allotment per unit
+- **Why:** Universally present in brochures, commonly asked by buyers. Zero fields today
+- **Work:** `parking` JSONB on projects. Admin form. Detail page section
+- **Effort:** Small
+
+---
+
+## Phase 2 — Property Detail Page Overhaul
+
+With Phase 1 data in place, the detail page needs a major upgrade to actually display it all.
+
+### 2.1 Tabbed Detail Page Layout `[T]`
+- **What:** Replace single scroll with horizontal tabs: About, Specs, Floor Plans, Location, Pricing, Gallery
+- **Why:** Truva uses 8 tabs. Our page will be very long with Phase 1 data added. Tabs improve navigation
+- **Work:** Refactor PropertyDetail into tabbed layout. Redistribute existing sections + new Phase 1 sections
+- **Effort:** Medium
+
+### 2.2 Price Breakdown Section `[T]`
+- **What:** Show: agreement value, per-sqft, what's included (ACs, fittings, etc.), other expenses (stamp duty, registration, maintenance)
+- **Why:** #1 buyer question is "what's the total cost?" Currently show only min-max range
+- **Work:** Add `price_inclusions` (array of strings) and `additional_costs` (JSONB) fields. Frontend section under Pricing tab
+- **Effort:** Small
+
+### 2.3 Image Gallery Upgrade `[T]`
+- **What:** Large primary image + thumbnail strip, left/right nav, "Show All" lightbox, image tag overlays
+- **Why:** Gallery is most-interacted element. Ours is basic single-image display
+- **Work:** Frontend component rewrite. Add `tag` field on project_images for labels ("Amenities View", "Pool Area", etc.)
+- **Effort:** Medium
+
+### 2.4 Site Plan + Cluster Plan Display `[B]`
+- **What:** Dedicated sections for site plan (project layout) and cluster plans (per-floor unit arrangement)
+- **Why:** These are not regular gallery images — they need context and their own section
+- **Work:** Add `site_plan` and `cluster_plan` to image_type enum. Dedicated UI sections on detail page
+- **Effort:** Small
+
+### 2.5 Construction Quality Section `[B]`
+- **What:** Construction technology name + quality attributes list (earthquake resistant, mivan, etc.)
+- **Why:** Key differentiator for under-construction projects. Zero fields today
+- **Work:** `construction_quality` JSONB on projects. Admin form. Detail page section
+- **Effort:** Small
+
+### 2.6 Views / Orientation `[B]`
+- **What:** Per-project or per-config view descriptions (hills, city skyline, garden, pool)
+- **Why:** Major selling point. Distinct from compass-direction facing
+- **Work:** `views` text array on projects or configs. Small admin + display change
+- **Effort:** Tiny
+
+### 2.7 Special Rooms in Configs `[B]`
+- **What:** Structured `special_rooms` array on configs (store, pooja_room, servant_room, study, utility)
+- **Why:** "3BHK + Store + Pooja Room" is a real product variant in Indian RE. Enables filtering
+- **Work:** Array field on configs + admin checkboxes + filter support
+- **Effort:** Small
+
+---
+
+## Phase 3 — Trust, Conversion + Key Features
+
+Features that build trust and convert browsers into leads.
+
+### 3.1 About / Team Page `[T]`
+- **What:** Founder story, team grid with photos, company values, media logos
+- **Why:** No about page = no trust. For high-value RE transactions, buyers need to know who's behind it
+- **Work:** Static page. Needs content: founder story, team photos, values
+- **Effort:** Small (code), Medium (content)
+
+### 3.2 Trust Signal Architecture `[T]`
+- **What:** Trust pillars below hero, "Featured In" media banner, verification badges on property cards
+- **Why:** Truva leads with trust. Our hero is transactional. Trust signals are scattered
+- **Work:** Homepage redesign — hero section + trust pillars + press logos. Badge component for cards
+- **Effort:** Medium
+
+### 3.3 Hero Section Redesign `[T]`
+- **What:** Emotional lifestyle imagery, tagline, social proof (family count), credibility badges
+- **Why:** Hero decides in 3 seconds if visitor stays. Ours sells numbers, not feelings
+- **Work:** New hero component with lifestyle imagery + emotional copy + social proof
+- **Effort:** Medium (needs photography/design assets)
+
+### 3.4 Download Brochure PDF `[TB]`
+- **What:** "Download Brochure" button on detail page. Admin uploads PDF per project
+- **Why:** Present in both Truva and every brochure. Acts as lead magnet
+- **Work:** `brochure_url` field on projects. Cloud storage upload in admin. Download button on detail page. Optional: gate behind name+phone form for lead capture
+- **Effort:** Small
+
+### 3.5 Video Tour Embed `[T]`
+- **What:** Video walkthrough player on detail page
+- **Why:** `video_url` field already exists in DB. Just needs frontend display
+- **Work:** YouTube/Vimeo embed component on detail page. Admin already has the field
+- **Effort:** Tiny
+
+### 3.6 EMI / Loan Calculator `[T]`
+- **What:** Frontend calculator: price, down payment %, rate, tenure -> monthly EMI, total interest
+- **Why:** Pure frontend, no API cost. Extremely useful for buyers. Truva has loan assistance CTA
+- **Work:** React component with sliders/inputs + EMI formula. Place in Pricing tab
+- **Effort:** Small
+
+### 3.7 Property Card Redesign `[T]`
+- **What:** Inline image carousel, image tags, more info density (BHK, area, price/sqft, locality)
+- **Why:** Cards are the primary browse interface. Ours show single image + minimal info
+- **Work:** New card component with carousel + tags + richer data display
+- **Effort:** Medium
+
+---
+
+## Phase 4 — Discovery + Engagement
+
+Better filtering, more ways to engage, SEO foundations.
+
+### 4.1 Advanced Filters `[T]`
+- **What:** Price range slider, BHK toggles, bathroom filter, locality chips with counts
+- **Why:** Current filters are basic dropdowns. These are standard in every property portal
+- **Work:** New filter sidebar component. Backend: query params for range/multi-select filters
+- **Effort:** Medium
+
+### 4.2 Schedule a Visit `[T]`
+- **What:** Dedicated "Schedule Visit" CTA with date/time preference
+- **Why:** Visit scheduling is distinct from general inquiry. Truva separates them
+- **Work:** Variant of inquiry form with date/time fields. Separate CTA button
+- **Effort:** Small
+
+### 4.3 Contextual CTAs `[T]`
+- **What:** Place relevant CTAs inside content sections — loan help near pricing, visit near gallery, etc.
+- **Why:** Truva places CTAs contextually. Ours are limited to floating WhatsApp + generic form
+- **Work:** CTA components placed within each detail page tab/section
+- **Effort:** Small
+
+### 4.4 Testimonials Carousel `[T]`
+- **What:** Named quotes with bold headlines, prev/next navigation, customer photos
+- **Why:** Current testimonials section is flat. Carousel with bold headlines is more impactful
+- **Work:** Carousel component upgrade
+- **Effort:** Small
+
+### 4.5 Sticky Mobile CTA Bar `[T]`
+- **What:** Fixed bottom bar with call/WhatsApp/inquiry buttons while scrolling property details
+- **Why:** Mobile users lose CTAs as they scroll. Sticky bar keeps conversion always accessible
+- **Work:** Fixed position component, visible only on mobile, on detail pages
+- **Effort:** Tiny
+
+### 4.6 Builder Address + Contact `[B]`
+- **What:** Add address, city, state, pincode, phone, email to builders table
+- **Why:** Buyers want to know where the builder is based. Currently missing
+- **Work:** DB migration + admin form + display on builder pages
+- **Effort:** Tiny
+
+### 4.7 Share Property `[T]`
+- **What:** Share button with Web Share API + WhatsApp + copy URL
+- **Why:** Easy to add, enables organic distribution
+- **Work:** Share button component on detail page
+- **Effort:** Tiny
+
+---
+
+## Phase 5 — Differentiation + SEO
+
+Longer-term investments for organic growth and competitive moat.
+
+### 5.1 Township / Locality Pages `[T]`
+- **What:** `/localities/[slug]` pages aggregating properties by area/society
+- **Why:** People search "flats in Oberoi Garden City". Huge SEO value
+- **Work:** New page template + locality data model + auto-aggregation from property locations
+- **Effort:** Medium
+
+### 5.2 Blog `[T]`
+- **What:** Blog section for home buying tips, area guides, market trends
+- **Why:** SEO engine. Truva has external blog. Can use MDX or headless CMS
+- **Work:** MDX blog setup in Next.js or Sanity/Contentful integration
+- **Effort:** Medium
+
+### 5.3 Sell Your House Page `[T]`
+- **What:** Marketing page for sellers with value props, process, testimonials, valuation form
+- **Why:** Opens a new revenue channel. Depends on business model decision
+- **Work:** Static marketing page + valuation form
+- **Effort:** Small (code), requires business decision
+
+### 5.4 3D Virtual Tours `[T]`
+- **What:** Matterport-style 3D tour embed
+- **Why:** `matterport_url` field already exists. Just needs frontend
+- **Work:** iFrame embed on detail page when URL present
+- **Effort:** Tiny (code), requires 3D scan content
+
+### 5.5 Vastu / Facing Direction `[T]`
+- **What:** Basic directional info (N/S/E/W facing) per unit or per config
+- **Why:** Important in Indian market. Simplified version of Truva's full vastu chart
+- **Work:** `facing` enum on configs. Display on detail page
+- **Effort:** Tiny
+
+### 5.6 Footer Redesign `[T]`
+- **What:** Buyer/seller segmented links, locality links, blog link, structured contact info
+- **Why:** Footer is underutilized SEO + navigation asset
+- **Work:** Footer component redesign
+- **Effort:** Small
+
+### 5.7 Lead Magnet Downloads `[T]`
+- **What:** Gated downloadable content (brochures, area guides) behind name+phone form
+- **Why:** Lead capture mechanism. Brochure download from 3.4 is the first one
+- **Work:** Gating UI component + lead storage
+- **Effort:** Small
+
+### 5.8 Careers Page `[T]`
+- **What:** Company values + open positions
+- **Why:** Low priority but easy. Builds brand
+- **Work:** Static section on about page
+- **Effort:** Tiny
+
+---
+
+## Our Existing Advantages (Preserve + Promote)
+
+Things we have that Truva doesn't:
+1. **Map view** (`/map`) for spatial browsing
+2. **User accounts + saved properties** (Truva has no login)
+3. **Text search** (Truva is filter-only)
+4. **Multi-city support** (Truva is Mumbai-only)
+5. **Full admin CMS** for property management
+6. **Google OAuth login**
+
+These should be prominently featured in marketing and not regressed during the roadmap work.
+
+---
+
+## Unresolved Questions
+
+1. Towers table or JSONB? Separate table gives more flexibility but more admin complexity
+-  Yes we can have it
+2. Specs: full room-by-room structured model vs simpler key-value pairs?
+- Key-value pairs with icon field. New icons table prefilled with available Lucide icons
+3. POIs: Google Places API auto-populate or manual entry only?
+- We will use Places API
+4. Brochure PDF: auto-generate from data or admin-upload only?
+- Admin upload
+5. Lead gating: gate brochure downloads behind form or keep ungated for UX?
+- No gating of brochures for now
+6. Sell page: is resale part of the business model or not?
+- no resale 
+7. Hero redesign: have lifestyle photography/design assets available?
+- we are fine currently
+8. Trust signals: have press/media mentions to display?
+- nothing so far
+
+

--- a/docs/plans/2026-02-20-unit-showcase-carousel-design.md
+++ b/docs/plans/2026-02-20-unit-showcase-carousel-design.md
@@ -1,0 +1,83 @@
+# Unit Showcase Carousel Design
+
+**Date**: 2026-02-20
+**Status**: Approved
+
+## Goal
+
+Replace the dated Tower Details cards + Unit Configurations table with a single combined carousel component. Each slide = one unit configuration with full-width floor plan image, specs, and tower info.
+
+## Approach
+
+Framer Motion carousel (no new deps). Already have framer-motion installed.
+
+## Component Structure
+
+```
+UnitShowcase (replaces Tower Details + Unit Configurations)
+├── SectionHeader ("Unit Plans & Configurations")
+├── PillNav (config pills: "2BHK Type A", "3BHK - Tower Iris", etc.)
+├── CarouselContainer (framer-motion AnimatePresence)
+│   └── ConfigSlide (one per config)
+│       ├── FloorPlanImage (full-width CldImage, click-to-expand)
+│       ├── SpecsBar (key stats row below image)
+│       └── TowerBadge (tower name + tower-level specs)
+├── ArrowNav (left/right chevrons overlaid on carousel)
+└── FloorPlanLightbox (framer-motion modal for expanded floor plan)
+```
+
+## Slide Layout
+
+```
+┌──────────────────────────────────────────┐
+│  ┌─────────┐  2BHK Type A  │ Tower Iris  │  ← Header bar
+│  │ bed/bath │  Floors 5-22  │ 25 floors   │
+│  └─────────┘               │             │
+├──────────────────────────────────────────┤
+│                                          │
+│         [Full-width Floor Plan]          │  ← CldImage, click to expand
+│         (aspect-ratio ~4:3)              │
+│                                          │
+├──────────────────────────────────────────┤
+│  Carpet     Super      Price     Balcony │  ← Specs bar
+│  850 sqft   1100 sqft  ₹85L     120sqft │
+└──────────────────────────────────────────┘
+```
+
+## Carousel Mechanics
+
+- `AnimatePresence mode="wait"` for slide transitions
+- Horizontal slide + fade animation (direction-aware)
+- `drag="x"` on slide with `onDragEnd` threshold for swipe
+- Keyboard: left/right arrow keys navigate
+
+## Pill Navigation
+
+- Horizontal scrollable row of pill buttons above carousel
+- Active pill: solid fill. Others: outlined
+- Click pill → jump to config slide
+- Auto-scroll active pill into view
+
+## Lightbox
+
+- Framer-motion overlay with backdrop blur
+- `layoutId` for smooth expand/collapse from thumbnail
+- Close: X button, click outside, Escape key
+
+## Data Grouping
+
+- Configs displayed in DB order (tower sort_order, then config order)
+- Pill label: `config_name || "{bedrooms}BHK"`, append tower name if tower exists
+- Tower-level specs (lifts, staircase, units/floor) shown in slide's tower badge
+
+## Empty/Fallback States
+
+- No floor plan → styled placeholder "Floor plan coming soon"
+- No configurations → section not rendered
+- Single config → carousel structure but hide arrows and pills
+
+## Files Affected
+
+- `src/app/(main)/properties/[slug]/page.tsx` — remove Tower Details + Unit Configurations, add UnitShowcase
+- `src/components/property/UnitShowcase.tsx` — new component (carousel + slides)
+- `src/components/property/FloorPlanLightbox.tsx` — new component (modal)

--- a/docs/plans/2026-02-20-unit-showcase-implementation.md
+++ b/docs/plans/2026-02-20-unit-showcase-implementation.md
@@ -1,0 +1,517 @@
+# Unit Showcase Carousel — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the Tower Details cards + Unit Configurations table with a single Framer Motion carousel where each slide shows one unit config with full-width floor plan, specs, and tower info.
+
+**Architecture:** Single `UnitShowcase` client component with pill nav, arrow nav, animated slides via `AnimatePresence`, and a lightbox modal. No new dependencies — uses framer-motion (already installed).
+
+**Tech Stack:** React 19, Framer Motion, Tailwind CSS, Lucide icons, existing `getImageUrl()` CDN helper.
+
+---
+
+### Task 1: Create FloorPlanLightbox component
+
+**Files:**
+- Create: `src/components/property/FloorPlanLightbox.tsx`
+
+**Context:** This is a reusable lightbox for floor plan images. Reference `src/components/property/PropertyGallery.tsx` for the existing lightbox pattern (lines 57-102). This version uses framer-motion for animations instead of plain conditionals.
+
+**Step 1: Create the component**
+
+Create `src/components/property/FloorPlanLightbox.tsx`:
+
+```tsx
+"use client";
+
+import { useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface FloorPlanLightboxProps {
+  src: string;
+  alt: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function FloorPlanLightbox({ src, alt, open, onClose }: FloorPlanLightboxProps) {
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onClose]);
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          onClick={onClose}
+        >
+          <Button
+            variant="ghost"
+            size="sm"
+            className="absolute top-4 right-4 text-white hover:bg-white/20"
+            onClick={onClose}
+          >
+            <X className="w-6 h-6" />
+          </Button>
+          <motion.img
+            src={src}
+            alt={alt}
+            className="max-w-[90vw] max-h-[85vh] object-contain rounded-lg"
+            initial={{ scale: 0.9, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.9, opacity: 0 }}
+            transition={{ type: "spring", damping: 25, stiffness: 300 }}
+            onClick={(e) => e.stopPropagation()}
+          />
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/components/property/FloorPlanLightbox.tsx
+git commit -m "feat: add FloorPlanLightbox component"
+```
+
+---
+
+### Task 2: Create UnitShowcase component
+
+**Files:**
+- Create: `src/components/property/UnitShowcase.tsx`
+
+**Context:**
+- Types: `Configuration` and `Tower` from `src/types/database.ts`
+- Formatters: `formatArea`, `formatPriceRange` from `src/lib/format.ts`
+  - `formatPriceRange(min, max, onRequest)` — for configs, call as `formatPriceRange(config.price, null, false)`
+  - `formatArea(sqft)` — returns `"850 sq.ft"` or `""` if null
+- Images: `getImageUrl(basePath, variant)` from `src/lib/image-urls.ts`
+  - Floor plan path stored in `config.floor_plan_cloudinary_id` (it's a CDN path, not a Cloudinary ID despite the name)
+  - Use `"card"` variant for the slide image, `"hero"` variant for lightbox
+- Icons: Use Lucide — `BedDouble`, `Bath`, `Building2`, `Layers`, `Maximize`, `ChevronLeft`, `ChevronRight`
+- The component is `"use client"` because it has state and animations
+
+**Step 1: Create the component**
+
+Create `src/components/property/UnitShowcase.tsx`. This is a large component — here's the full implementation:
+
+```tsx
+"use client";
+
+import { useState, useRef, useCallback, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { ChevronLeft, ChevronRight, BedDouble, Bath, Building2, Layers, Maximize } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { FloorPlanLightbox } from "./FloorPlanLightbox";
+import { formatArea, formatPriceRange } from "@/lib/format";
+import { getImageUrl } from "@/lib/image-urls";
+import type { Configuration, Tower } from "@/types/database";
+
+interface UnitShowcaseProps {
+  configurations: Configuration[];
+  towers?: Tower[];
+}
+
+function getConfigLabel(config: Configuration): string {
+  const name = config.config_name || (config.bedrooms ? `${config.bedrooms} BHK` : "Unit");
+  if (config.tower?.name) return `${name} — ${config.tower.name}`;
+  return name;
+}
+
+const slideVariants = {
+  enter: (direction: number) => ({
+    x: direction > 0 ? 200 : -200,
+    opacity: 0,
+  }),
+  center: { x: 0, opacity: 1 },
+  exit: (direction: number) => ({
+    x: direction > 0 ? -200 : 200,
+    opacity: 0,
+  }),
+};
+
+export function UnitShowcase({ configurations, towers }: UnitShowcaseProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [direction, setDirection] = useState(0);
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+  const pillsRef = useRef<HTMLDivElement>(null);
+
+  const config = configurations[activeIndex];
+  const tower = config?.tower || (config?.tower_id ? towers?.find((t) => t.id === config.tower_id) : undefined);
+  const showNav = configurations.length > 1;
+
+  const goTo = useCallback(
+    (index: number) => {
+      setDirection(index > activeIndex ? 1 : -1);
+      setActiveIndex(index);
+    },
+    [activeIndex]
+  );
+
+  const goNext = useCallback(() => {
+    if (activeIndex < configurations.length - 1) goTo(activeIndex + 1);
+  }, [activeIndex, configurations.length, goTo]);
+
+  const goPrev = useCallback(() => {
+    if (activeIndex > 0) goTo(activeIndex - 1);
+  }, [activeIndex, goTo]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "ArrowRight") goNext();
+      if (e.key === "ArrowLeft") goPrev();
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [goNext, goPrev]);
+
+  // Auto-scroll active pill into view
+  useEffect(() => {
+    if (!pillsRef.current) return;
+    const activePill = pillsRef.current.children[activeIndex] as HTMLElement;
+    if (activePill) {
+      activePill.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "center" });
+    }
+  }, [activeIndex]);
+
+  if (!configurations.length) return null;
+
+  const floorPlanSrc = config.floor_plan_cloudinary_id
+    ? getImageUrl(config.floor_plan_cloudinary_id, "card")
+    : null;
+  const floorPlanHero = config.floor_plan_cloudinary_id
+    ? getImageUrl(config.floor_plan_cloudinary_id, "hero")
+    : null;
+
+  // Collect specs that have data
+  const specs: { label: string; value: string }[] = [];
+  if (config.carpet_area_sqft) specs.push({ label: "Carpet", value: formatArea(config.carpet_area_sqft) });
+  if (config.super_area_sqft) specs.push({ label: "Super Area", value: formatArea(config.super_area_sqft) });
+  if (config.built_up_area_sqft) specs.push({ label: "Built-up", value: formatArea(config.built_up_area_sqft) });
+  if (config.balcony_area_sqft) specs.push({ label: "Balcony", value: formatArea(config.balcony_area_sqft) });
+  if (config.price) specs.push({ label: "Price", value: `₹${formatPriceRange(config.price, null, false)}` });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Layers className="w-5 h-5" />
+          Unit Plans & Configurations
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Pill Navigation */}
+        {showNav && (
+          <div ref={pillsRef} className="flex gap-2 overflow-x-auto pb-2 scrollbar-hide">
+            {configurations.map((c, i) => (
+              <button
+                key={c.id}
+                onClick={() => goTo(i)}
+                className={`shrink-0 rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+                  i === activeIndex
+                    ? "bg-gray-900 text-white"
+                    : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                }`}
+              >
+                {getConfigLabel(c)}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Carousel */}
+        <div className="relative overflow-hidden rounded-xl">
+          {/* Arrow buttons */}
+          {showNav && activeIndex > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="absolute left-2 top-1/2 -translate-y-1/2 z-10 bg-white/80 hover:bg-white shadow-md rounded-full h-9 w-9 p-0"
+              onClick={goPrev}
+            >
+              <ChevronLeft className="w-5 h-5" />
+            </Button>
+          )}
+          {showNav && activeIndex < configurations.length - 1 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="absolute right-2 top-1/2 -translate-y-1/2 z-10 bg-white/80 hover:bg-white shadow-md rounded-full h-9 w-9 p-0"
+              onClick={goNext}
+            >
+              <ChevronRight className="w-5 h-5" />
+            </Button>
+          )}
+
+          <AnimatePresence mode="wait" custom={direction}>
+            <motion.div
+              key={config.id}
+              custom={direction}
+              variants={slideVariants}
+              initial="enter"
+              animate="center"
+              exit="exit"
+              transition={{ duration: 0.3, ease: "easeInOut" }}
+              drag={showNav ? "x" : false}
+              dragConstraints={{ left: 0, right: 0 }}
+              dragElastic={0.1}
+              onDragEnd={(_, info) => {
+                if (info.offset.x < -50) goNext();
+                else if (info.offset.x > 50) goPrev();
+              }}
+            >
+              {/* Header bar */}
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-2 mb-4 px-1">
+                <h4 className="text-lg font-semibold">
+                  {config.config_name || (config.bedrooms ? `${config.bedrooms} BHK` : "Unit")}
+                </h4>
+                <div className="flex items-center gap-3 text-sm text-gray-500">
+                  {config.bedrooms != null && (
+                    <span className="flex items-center gap-1">
+                      <BedDouble className="w-4 h-4" /> {config.bedrooms}
+                    </span>
+                  )}
+                  {config.bathrooms != null && (
+                    <span className="flex items-center gap-1">
+                      <Bath className="w-4 h-4" /> {config.bathrooms}
+                    </span>
+                  )}
+                  {config.floor_from != null && config.floor_to != null && (
+                    <span>Floors {config.floor_from}–{config.floor_to}</span>
+                  )}
+                </div>
+                {tower && (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700">
+                    <Building2 className="w-3.5 h-3.5" />
+                    {tower.name}
+                    {tower.floor_from != null && tower.floor_to != null && (
+                      <span className="text-blue-500 ml-1">· {tower.floor_to - tower.floor_from + 1} floors</span>
+                    )}
+                  </span>
+                )}
+              </div>
+
+              {/* Floor Plan Image */}
+              {floorPlanSrc ? (
+                <button
+                  onClick={() => setLightboxOpen(true)}
+                  className="relative w-full group cursor-zoom-in"
+                >
+                  <img
+                    src={floorPlanSrc}
+                    alt={`Floor plan — ${getConfigLabel(config)}`}
+                    className="w-full rounded-lg object-contain bg-gray-50 border"
+                  />
+                  <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity bg-black/10 rounded-lg">
+                    <span className="flex items-center gap-1.5 bg-white/90 px-3 py-1.5 rounded-full text-sm font-medium shadow">
+                      <Maximize className="w-4 h-4" /> View Full Size
+                    </span>
+                  </div>
+                </button>
+              ) : (
+                <div className="w-full aspect-[4/3] rounded-lg bg-gray-50 border border-dashed border-gray-200 flex items-center justify-center">
+                  <p className="text-sm text-gray-400">Floor plan coming soon</p>
+                </div>
+              )}
+
+              {/* Specs bar */}
+              {specs.length > 0 && (
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-4 mt-4 px-1">
+                  {specs.map((s) => (
+                    <div key={s.label}>
+                      <p className="text-xs text-gray-500">{s.label}</p>
+                      <p className="text-sm font-semibold">{s.value}</p>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {/* Tower details (secondary info) */}
+              {tower && (tower.lifts_count || tower.staircase_info || tower.units_per_floor) && (
+                <div className="flex flex-wrap gap-x-4 gap-y-1 mt-3 px-1 text-xs text-gray-500">
+                  {tower.units_per_floor && <span>{tower.units_per_floor} units/floor</span>}
+                  {tower.lifts_count && (
+                    <span>
+                      {tower.lifts_count} {tower.lift_type || ""} lift{tower.lifts_count > 1 ? "s" : ""}
+                    </span>
+                  )}
+                  {tower.staircase_info && <span>{tower.staircase_info}</span>}
+                </div>
+              )}
+            </motion.div>
+          </AnimatePresence>
+        </div>
+
+        {/* Slide counter */}
+        {showNav && (
+          <p className="text-center text-xs text-gray-400">
+            {activeIndex + 1} / {configurations.length}
+          </p>
+        )}
+      </CardContent>
+
+      {/* Lightbox */}
+      {floorPlanHero && (
+        <FloorPlanLightbox
+          src={floorPlanHero}
+          alt={`Floor plan — ${getConfigLabel(config)}`}
+          open={lightboxOpen}
+          onClose={() => setLightboxOpen(false)}
+        />
+      )}
+    </Card>
+  );
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/components/property/UnitShowcase.tsx
+git commit -m "feat: add UnitShowcase carousel component"
+```
+
+---
+
+### Task 3: Wire UnitShowcase into the property detail page
+
+**Files:**
+- Modify: `src/app/(main)/properties/[slug]/page.tsx`
+
+**Context:** The page currently renders:
+- Tower Details section at lines 279-304 (Card with tower cards grid)
+- Unit Configurations section at lines 362-416 (Card with table)
+
+Both need to be replaced with a single `<UnitShowcase>` component. The section should appear where Tower Details currently sits.
+
+**Step 1: Replace Tower Details + Unit Configurations with UnitShowcase**
+
+In `src/app/(main)/properties/[slug]/page.tsx`:
+
+1. Add import at top (near other property component imports ~line 12):
+```tsx
+import { UnitShowcase } from "@/components/property/UnitShowcase";
+```
+
+2. Remove the `Home` import from lucide (line 4) if it's only used by Unit Configurations section. Keep `Car` and others.
+
+3. Replace the Tower Details block (lines 279-304) with:
+```tsx
+{project.configurations && project.configurations.length > 0 && (
+  <AnimateIn delay={0.28}>
+    <UnitShowcase
+      configurations={project.configurations}
+      towers={project.towers}
+    />
+  </AnimateIn>
+)}
+```
+
+4. Delete the entire Unit Configurations block (lines 362-416) — the IIFE that renders the table.
+
+**Step 2: Verify the build compiles**
+
+Run: `npx next build` (or `npm run dev` and check the page)
+Expected: No TypeScript errors, page renders with new carousel
+
+**Step 3: Commit**
+
+```bash
+git add src/app/(main)/properties/[slug]/page.tsx
+git commit -m "feat: replace tower details + unit configs with UnitShowcase carousel"
+```
+
+---
+
+### Task 4: Add scrollbar-hide utility
+
+**Files:**
+- Check: `src/app/globals.css` (or wherever Tailwind base styles live)
+
+**Context:** The pill nav uses `scrollbar-hide` class for clean horizontal scrolling. Need to ensure this utility exists.
+
+**Step 1: Add scrollbar-hide if missing**
+
+Check if `scrollbar-hide` is already defined in the CSS. If not, add to the global CSS:
+
+```css
+@layer utilities {
+  .scrollbar-hide {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;
+  }
+}
+```
+
+**Step 2: Commit (if changed)**
+
+```bash
+git add src/app/globals.css
+git commit -m "feat: add scrollbar-hide utility"
+```
+
+---
+
+### Task 5: Visual QA and polish
+
+**Files:**
+- Possibly modify: `src/components/property/UnitShowcase.tsx`
+
+**Step 1: Test with real data**
+
+Open the property detail page in the browser for a project that has:
+- Multiple configurations
+- Configurations linked to towers
+- At least one config with `floor_plan_cloudinary_id` set
+
+Verify:
+- Pill nav scrolls, active pill highlights
+- Arrow nav works (left/right)
+- Swipe gesture works on mobile
+- Keyboard arrow keys navigate
+- Floor plan click opens lightbox
+- Lightbox closes on Escape, click outside, X button
+- Specs bar shows only available data
+- Tower badge shows tower info
+- Single-config projects hide pills and arrows
+- Configs without floor plans show placeholder
+
+**Step 2: Test empty states**
+
+- Project with no configurations → section should not render
+- Config with no floor plan → shows "Floor plan coming soon" placeholder
+- Config with no tower → no tower badge shown
+
+**Step 3: Fix any issues found, commit**
+
+```bash
+git add -A
+git commit -m "fix: UnitShowcase visual polish"
+```
+
+---
+
+## Unresolved Questions
+
+- `floor_plan_cloudinary_id` — do any configs currently have this field populated in the DB? If not, the floor plan images will all show placeholders until data is seeded.
+- Should the `Home` icon import be removed from page.tsx or is it used elsewhere on that page?

--- a/src/app/(main)/properties/[slug]/page.tsx
+++ b/src/app/(main)/properties/[slug]/page.tsx
@@ -17,6 +17,7 @@ import { InquiryForm } from "@/components/property/InquiryForm";
 import { AnimateIn } from "@/components/ui/AnimateIn";
 import { DynamicIcon } from "@/components/ui/DynamicIcon";
 import { UnitShowcase } from "@/components/property/UnitShowcase";
+import { MobileCtaBar } from "@/components/property/MobileCtaBar";
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -397,7 +398,7 @@ export default async function PropertyDetailPage({ params }: PageProps) {
               />
 
               {/* Inquiry Form */}
-              <Card>
+              <Card id="inquiry-form">
                 <CardHeader>
                   <CardTitle className="text-lg">Request Callback</CardTitle>
                 </CardHeader>
@@ -436,6 +437,12 @@ export default async function PropertyDetailPage({ params }: PageProps) {
           </div>
         </div>
       </div>
+
+      {/* Floating mobile CTA — visible when inquiry form scrolled out of view */}
+      <MobileCtaBar
+        propertyTitle={project.name}
+        observeId="inquiry-form"
+      />
     </div>
   );
 }

--- a/src/app/(main)/properties/[slug]/page.tsx
+++ b/src/app/(main)/properties/[slug]/page.tsx
@@ -1,9 +1,9 @@
 import { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { MapPin, Building2, Calendar, Home, Check, ChevronRight } from "lucide-react";
+import { MapPin, Building2, Calendar, Home, Check, ChevronRight, Car } from "lucide-react";
 import { getProjectBySlug, getProjectSlugs } from "@/lib/queries/projects";
-import { formatPriceRange, formatArea, formatDate } from "@/lib/format";
+import { formatPrice, formatPriceRange, formatArea, formatDate } from "@/lib/format";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { LocationMap } from "@/components/map/LocationMap";
@@ -14,6 +14,7 @@ import { ProjectDetailStats } from "@/components/property/ProjectDetailStats";
 import { QuickCtaSidebar } from "@/components/property/QuickCtaSidebar";
 import { InquiryForm } from "@/components/property/InquiryForm";
 import { AnimateIn } from "@/components/ui/AnimateIn";
+import { DynamicIcon } from "@/components/ui/DynamicIcon";
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -152,10 +153,63 @@ export default async function PropertyDetailPage({ params }: PageProps) {
                           : "N/A"}
                       </p>
                     </div>
+                    {project.price_per_sqft && (
+                      <div>
+                        <p className="text-sm text-gray-500">Price / Sq Ft</p>
+                        <p className="font-semibold">{formatPrice(project.price_per_sqft)}/sqft</p>
+                      </div>
+                    )}
                   </div>
                 </CardContent>
               </Card>
             </AnimateIn>
+
+            {/* Highlights */}
+            {project.highlights?.length > 0 && (
+              <AnimateIn delay={0.05}>
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Project Highlights</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                      {project.highlights.map((h, i) => (
+                        <div key={i} className="flex items-start gap-3 p-3 rounded-lg bg-gray-50">
+                          <span className="text-primary mt-0.5">
+                            <DynamicIcon name={h.icon_name || "circle-check"} className="w-5 h-5" />
+                          </span>
+                          <span>{h.text}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </CardContent>
+                </Card>
+              </AnimateIn>
+            )}
+
+            {/* Specifications */}
+            {project.specifications?.length > 0 && (
+              <AnimateIn delay={0.08}>
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Specifications</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="divide-y">
+                      {project.specifications.map((spec, i) => (
+                        <div key={i} className="flex items-center justify-between py-3">
+                          <div className="flex items-center gap-2 text-gray-600">
+                            <DynamicIcon name={spec.icon_name || "circle"} className="w-4 h-4" />
+                            <span>{spec.label}</span>
+                          </div>
+                          <span className="font-medium">{spec.value}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </CardContent>
+                </Card>
+              </AnimateIn>
+            )}
 
             {/* Location */}
             <AnimateIn delay={0.1}>
@@ -213,6 +267,34 @@ export default async function PropertyDetailPage({ params }: PageProps) {
             {project.project_details_extra && (
               <AnimateIn delay={0.25}>
                 <ProjectDetailStats data={project.project_details_extra} vastuCompliant={project.vastu_compliant} />
+              </AnimateIn>
+            )}
+
+            {/* Towers */}
+            {project.towers && project.towers.length > 0 && (
+              <AnimateIn delay={0.28}>
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Tower Details</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                      {project.towers.map((tower) => (
+                        <div key={tower.id} className="p-4 rounded-lg border bg-gray-50">
+                          <h4 className="font-semibold mb-2">{tower.name}</h4>
+                          <div className="space-y-1 text-sm text-gray-600">
+                            {tower.floor_from != null && tower.floor_to != null && (
+                              <p>Floors: {tower.floor_from} to {tower.floor_to}</p>
+                            )}
+                            {tower.units_per_floor && <p>{tower.units_per_floor} units per floor</p>}
+                            {tower.lifts_count && <p>{tower.lifts_count} {tower.lift_type || ""} lifts</p>}
+                            {tower.staircase_info && <p>{tower.staircase_info}</p>}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </CardContent>
+                </Card>
               </AnimateIn>
             )}
 

--- a/src/app/(main)/properties/[slug]/page.tsx
+++ b/src/app/(main)/properties/[slug]/page.tsx
@@ -1,9 +1,9 @@
 import { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { MapPin, Building2, Calendar, Home, Check, ChevronRight, Car } from "lucide-react";
+import { MapPin, Building2, Calendar, Check, ChevronRight, Car } from "lucide-react";
 import { getProjectBySlug, getProjectSlugs } from "@/lib/queries/projects";
-import { formatPrice, formatPriceRange, formatArea, formatDate } from "@/lib/format";
+import { formatPrice, formatPriceRange, formatDate } from "@/lib/format";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { LocationMap } from "@/components/map/LocationMap";
@@ -16,6 +16,7 @@ import { QuickCtaSidebar } from "@/components/property/QuickCtaSidebar";
 import { InquiryForm } from "@/components/property/InquiryForm";
 import { AnimateIn } from "@/components/ui/AnimateIn";
 import { DynamicIcon } from "@/components/ui/DynamicIcon";
+import { UnitShowcase } from "@/components/property/UnitShowcase";
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -275,31 +276,13 @@ export default async function PropertyDetailPage({ params }: PageProps) {
               </AnimateIn>
             )}
 
-            {/* Towers */}
-            {project.towers && project.towers.length > 0 && (
+            {/* Unit Plans & Configurations */}
+            {project.configurations && project.configurations.length > 0 && (
               <AnimateIn delay={0.28}>
-                <Card>
-                  <CardHeader>
-                    <CardTitle>Tower Details</CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                      {project.towers.map((tower) => (
-                        <div key={tower.id} className="p-4 rounded-lg border bg-gray-50">
-                          <h4 className="font-semibold mb-2">{tower.name}</h4>
-                          <div className="space-y-1 text-sm text-gray-600">
-                            {tower.floor_from != null && tower.floor_to != null && (
-                              <p>Floors: {tower.floor_from} to {tower.floor_to}</p>
-                            )}
-                            {tower.units_per_floor && <p>{tower.units_per_floor} units per floor</p>}
-                            {tower.lifts_count && <p>{tower.lifts_count} {tower.lift_type || ""} lifts</p>}
-                            {tower.staircase_info && <p>{tower.staircase_info}</p>}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </CardContent>
-                </Card>
+                <UnitShowcase
+                  configurations={project.configurations}
+                  towers={project.towers}
+                />
               </AnimateIn>
             )}
 
@@ -359,61 +342,6 @@ export default async function PropertyDetailPage({ params }: PageProps) {
             )}
 
             {/* Configurations */}
-            {project.configurations && project.configurations.length > 0 && (() => {
-              const configs = project.configurations!;
-              const hasTypeLabel = configs.some((c) => c.type_label);
-              const hasTower = configs.some((c) => c.tower);
-              const hasFloorRange = configs.some((c) => c.floor_from != null);
-              const hasSuperArea = configs.some((c) => c.super_area_sqft);
-              return (
-                <Card>
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2">
-                      <Home className="w-5 h-5" />
-                      Unit Configurations
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="overflow-x-auto">
-                      <table className="w-full text-sm">
-                        <thead>
-                          <tr className="border-b">
-                            {hasTypeLabel && <th className="text-left py-2 font-medium">Type</th>}
-                            <th className="text-left py-2 font-medium">Config</th>
-                            {hasTower && <th className="text-left py-2 font-medium">Tower</th>}
-                            {hasFloorRange && <th className="text-left py-2 font-medium">Floors</th>}
-                            <th className="text-left py-2 font-medium">Carpet Area</th>
-                            {hasSuperArea && <th className="text-left py-2 font-medium">Super Area</th>}
-                            <th className="text-left py-2 font-medium">Price</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {configs.map((config) => (
-                            <tr key={config.id} className="border-b last:border-0">
-                              {hasTypeLabel && <td className="py-3">{config.type_label || "—"}</td>}
-                              <td className="py-3">{config.config_name || `${config.bedrooms} BHK`}</td>
-                              {hasTower && <td className="py-3">{config.tower?.name || "—"}</td>}
-                              {hasFloorRange && (
-                                <td className="py-3">
-                                  {config.floor_from != null && config.floor_to != null
-                                    ? `${config.floor_from}–${config.floor_to}`
-                                    : "—"}
-                                </td>
-                              )}
-                              <td className="py-3">{formatArea(config.carpet_area_sqft)}</td>
-                              {hasSuperArea && <td className="py-3">{formatArea(config.super_area_sqft)}</td>}
-                              <td className="py-3">
-                                {config.price ? formatPriceRange(config.price, null, false) : "On Request"}
-                              </td>
-                            </tr>
-                          ))}
-                        </tbody>
-                      </table>
-                    </div>
-                  </CardContent>
-                </Card>
-              );
-            })()}
 
             {/* Amenities */}
             {project.amenities && project.amenities.length > 0 && (

--- a/src/app/(main)/properties/page.tsx
+++ b/src/app/(main)/properties/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from "next";
 import { getProjects, getCities } from "@/lib/queries/projects";
 import { PropertyGrid } from "@/components/property/PropertyGrid";
 import { PropertyFilters } from "@/components/property/PropertyFilters";
+import { SortDropdown } from "@/components/property/SortDropdown";
 import { MapListToggle } from "@/components/map/MapListToggle";
 import type { ProjectFilters, PropertyType, ProjectStatus } from "@/types/database";
 
@@ -17,6 +18,7 @@ interface PageProps {
     type?: string;
     status?: string;
     q?: string;
+    sort?: string;
   }>;
 }
 
@@ -28,6 +30,7 @@ async function PropertiesContent({ searchParams }: PageProps) {
     property_type: params.type as PropertyType,
     status: params.status as ProjectStatus,
     search: params.q,
+    sort: params.sort as ProjectFilters["sort"],
   };
 
   const [projects, cities] = await Promise.all([
@@ -38,7 +41,10 @@ async function PropertiesContent({ searchParams }: PageProps) {
   return (
     <>
       <PropertyFilters cities={cities} />
-      <p className="text-sm text-gray-500 mb-4">{projects.length} properties found</p>
+      <div className="flex items-center justify-between mb-4">
+        <p className="text-sm text-gray-500">{projects.length} properties found</p>
+        <SortDropdown />
+      </div>
       <PropertyGrid projects={projects} />
     </>
   );

--- a/src/app/admin/properties/[id]/page.tsx
+++ b/src/app/admin/properties/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { getProjectById, getUniqueCities, getAllBuilders, getAllAmenities } from "@/lib/queries/admin";
+import { getIcons } from "@/lib/queries/projects";
 import { PropertyForm } from "../_components/PropertyForm";
 import { projectToFormValues } from "../_components/property-schema";
 import { updatePropertyAction, deletePropertyAction } from "../actions";
@@ -11,11 +12,12 @@ interface Props {
 export default async function EditPropertyPage({ params }: Props) {
   const { id } = await params;
 
-  const [project, cities, builders, amenities] = await Promise.all([
+  const [project, cities, builders, amenities, icons] = await Promise.all([
     getProjectById(id),
     getUniqueCities(),
     getAllBuilders(),
     getAllAmenities(),
+    getIcons(),
   ]);
 
   if (!project) notFound();
@@ -42,6 +44,7 @@ export default async function EditPropertyPage({ params }: Props) {
         builders={builders}
         cities={cities}
         amenities={amenities}
+        icons={icons}
         onSubmit={handleSubmit}
         onDelete={handleDelete}
       />

--- a/src/app/admin/properties/_components/ConfigurationsEditor.tsx
+++ b/src/app/admin/properties/_components/ConfigurationsEditor.tsx
@@ -3,14 +3,15 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import type { Configuration } from "@/types/database";
+import type { Configuration, Tower } from "@/types/database";
 
 interface ConfigurationsEditorProps {
   configurations: Partial<Configuration>[];
+  towers: Partial<Tower>[];
   onChange: (configs: Partial<Configuration>[]) => void;
 }
 
-export function ConfigurationsEditor({ configurations, onChange }: ConfigurationsEditorProps) {
+export function ConfigurationsEditor({ configurations, towers, onChange }: ConfigurationsEditorProps) {
   const addConfig = () => {
     onChange([
       ...configurations,
@@ -21,7 +22,14 @@ export function ConfigurationsEditor({ configurations, onChange }: Configuration
         config_name: "",
         carpet_area_sqft: null,
         built_up_area_sqft: null,
+        balcony_area_sqft: null,
+        covered_area_sqft: null,
+        super_area_sqft: null,
         price: null,
+        tower_id: null,
+        floor_from: null,
+        floor_to: null,
+        type_label: null,
       },
     ]);
   };
@@ -63,6 +71,15 @@ export function ConfigurationsEditor({ configurations, onChange }: Configuration
             </div>
 
             <div className="space-y-2">
+              <Label>Type Label</Label>
+              <Input
+                value={config.type_label || ""}
+                onChange={(e) => updateConfig(i, "type_label", e.target.value || null)}
+                placeholder="Type A"
+              />
+            </div>
+
+            <div className="space-y-2">
               <Label>Bedrooms</Label>
               <Input
                 type="number"
@@ -79,6 +96,44 @@ export function ConfigurationsEditor({ configurations, onChange }: Configuration
                 value={config.bathrooms ?? ""}
                 onChange={(e) => updateConfig(i, "bathrooms", e.target.value ? Number(e.target.value) : null)}
                 placeholder="2"
+              />
+            </div>
+
+            {towers.length > 0 && (
+              <div className="space-y-2">
+                <Label>Tower</Label>
+                <select
+                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  value={config.tower_id || ""}
+                  onChange={(e) => updateConfig(i, "tower_id", e.target.value || null)}
+                >
+                  <option value="">No tower</option>
+                  {towers.map((tower) => (
+                    <option key={tower.id} value={tower.id}>
+                      {tower.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <Label>Floor From</Label>
+              <Input
+                type="number"
+                value={config.floor_from ?? ""}
+                onChange={(e) => updateConfig(i, "floor_from", e.target.value ? Number(e.target.value) : null)}
+                placeholder="1"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Floor To</Label>
+              <Input
+                type="number"
+                value={config.floor_to ?? ""}
+                onChange={(e) => updateConfig(i, "floor_to", e.target.value ? Number(e.target.value) : null)}
+                placeholder="25"
               />
             </div>
 
@@ -99,6 +154,36 @@ export function ConfigurationsEditor({ configurations, onChange }: Configuration
                 value={config.built_up_area_sqft ?? ""}
                 onChange={(e) => updateConfig(i, "built_up_area_sqft", e.target.value ? Number(e.target.value) : null)}
                 placeholder="1100"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Balcony Area (sqft)</Label>
+              <Input
+                type="number"
+                value={config.balcony_area_sqft ?? ""}
+                onChange={(e) => updateConfig(i, "balcony_area_sqft", e.target.value ? Number(e.target.value) : null)}
+                placeholder="100"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Covered Area (sqft)</Label>
+              <Input
+                type="number"
+                value={config.covered_area_sqft ?? ""}
+                onChange={(e) => updateConfig(i, "covered_area_sqft", e.target.value ? Number(e.target.value) : null)}
+                placeholder="950"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Super Area (sqft)</Label>
+              <Input
+                type="number"
+                value={config.super_area_sqft ?? ""}
+                onChange={(e) => updateConfig(i, "super_area_sqft", e.target.value ? Number(e.target.value) : null)}
+                placeholder="1400"
               />
             </div>
 

--- a/src/app/admin/properties/_components/HighlightsEditor.tsx
+++ b/src/app/admin/properties/_components/HighlightsEditor.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { ProjectHighlight, Icon } from "@/types/database";
+
+interface HighlightsEditorProps {
+  highlights: ProjectHighlight[];
+  icons: Icon[];
+  onChange: (highlights: ProjectHighlight[]) => void;
+}
+
+export function HighlightsEditor({ highlights, icons, onChange }: HighlightsEditorProps) {
+  const addHighlight = () => {
+    onChange([...highlights, { text: "", icon_id: null, icon_name: null }]);
+  };
+
+  const updateHighlight = (index: number, field: keyof ProjectHighlight, value: string | null) => {
+    const updated = [...highlights];
+    updated[index] = { ...updated[index], [field]: value };
+    onChange(updated);
+  };
+
+  const setIcon = (index: number, iconId: string) => {
+    const icon = icons.find((i) => i.id === iconId);
+    const updated = [...highlights];
+    updated[index] = {
+      ...updated[index],
+      icon_id: iconId || null,
+      icon_name: icon?.lucide_name || null,
+    };
+    onChange(updated);
+  };
+
+  const removeHighlight = (index: number) => {
+    const updated = [...highlights];
+    updated.splice(index, 1);
+    onChange(updated);
+  };
+
+  return (
+    <div className="space-y-4">
+      {highlights.map((h, i) => (
+        <div key={i} className="p-4 border rounded-lg space-y-4 relative">
+          <button
+            type="button"
+            onClick={() => removeHighlight(i)}
+            className="absolute top-2 right-2 p-1 text-muted-foreground hover:text-red-500 transition-colors"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label>Highlight Text</Label>
+              <Input
+                value={h.text}
+                onChange={(e) => updateHighlight(i, "text", e.target.value)}
+                placeholder="e.g., 12 Ultra Luxury Sky-Villas"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Icon</Label>
+              <select
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                value={h.icon_id || ""}
+                onChange={(e) => setIcon(i, e.target.value)}
+              >
+                <option value="">No icon</option>
+                {icons.map((icon) => (
+                  <option key={icon.id} value={icon.id}>
+                    {icon.name} ({icon.lucide_name})
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </div>
+      ))}
+
+      <Button type="button" variant="outline" onClick={addHighlight}>
+        <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+        </svg>
+        Add Highlight
+      </Button>
+    </div>
+  );
+}

--- a/src/app/admin/properties/_components/POIsEditor.tsx
+++ b/src/app/admin/properties/_components/POIsEditor.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { PointOfInterest } from "@/types/database";
+
+interface POIsEditorProps {
+  pois: PointOfInterest[];
+  onChange: (pois: PointOfInterest[]) => void;
+}
+
+const CATEGORIES = ["transport", "education", "healthcare", "shopping", "food", "lifestyle", "notable"];
+
+export function POIsEditor({ pois, onChange }: POIsEditorProps) {
+  const addPOI = () => {
+    onChange([...pois, { name: "", category: "notable", distance_value: 0, distance_unit: "km" }]);
+  };
+
+  const updatePOI = (index: number, field: keyof PointOfInterest, value: string | number) => {
+    const updated = [...pois];
+    updated[index] = { ...updated[index], [field]: value };
+    onChange(updated);
+  };
+
+  const removePOI = (index: number) => {
+    const updated = [...pois];
+    updated.splice(index, 1);
+    onChange(updated);
+  };
+
+  return (
+    <div className="space-y-4">
+      {pois.map((poi, i) => (
+        <div key={i} className="p-4 border rounded-lg space-y-4 relative">
+          <button
+            type="button"
+            onClick={() => removePOI(i)}
+            className="absolute top-2 right-2 p-1 text-muted-foreground hover:text-red-500 transition-colors"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+
+          <div className="grid gap-4 sm:grid-cols-4">
+            <div className="space-y-2">
+              <Label>Name</Label>
+              <Input
+                value={poi.name}
+                onChange={(e) => updatePOI(i, "name", e.target.value)}
+                placeholder="e.g., Elante Mall"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Category</Label>
+              <select
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                value={poi.category}
+                onChange={(e) => updatePOI(i, "category", e.target.value)}
+              >
+                {CATEGORIES.map((cat) => (
+                  <option key={cat} value={cat}>
+                    {cat.charAt(0).toUpperCase() + cat.slice(1)}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Distance</Label>
+              <Input
+                type="number"
+                step="0.1"
+                value={poi.distance_value}
+                onChange={(e) => updatePOI(i, "distance_value", Number(e.target.value))}
+                placeholder="5.5"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Unit</Label>
+              <select
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                value={poi.distance_unit}
+                onChange={(e) => updatePOI(i, "distance_unit", e.target.value)}
+              >
+                <option value="km">km</option>
+                <option value="min">min</option>
+              </select>
+            </div>
+          </div>
+        </div>
+      ))}
+
+      <Button type="button" variant="outline" onClick={addPOI}>
+        <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+        </svg>
+        Add Point of Interest
+      </Button>
+    </div>
+  );
+}

--- a/src/app/admin/properties/_components/ParkingEditor.tsx
+++ b/src/app/admin/properties/_components/ParkingEditor.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { ProjectParking } from "@/types/database";
+
+interface ParkingEditorProps {
+  parking: ProjectParking | null;
+  onChange: (parking: ProjectParking | null) => void;
+}
+
+const PARKING_TYPES = ["stilt", "basement", "open", "covered", "multi-level"];
+
+export function ParkingEditor({ parking, onChange }: ParkingEditorProps) {
+  const data: ProjectParking = parking || { types: [], basement_levels: null, guest_parking: false, allotment: null };
+
+  const update = (partial: Partial<ProjectParking>) => {
+    onChange({ ...data, ...partial });
+  };
+
+  const toggleType = (type: string) => {
+    const types = data.types.includes(type)
+      ? data.types.filter((t) => t !== type)
+      : [...data.types, type];
+    update({ types });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label>Parking Types</Label>
+        <div className="flex flex-wrap gap-2">
+          {PARKING_TYPES.map((type) => (
+            <label key={type} className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={data.types.includes(type)}
+                onChange={() => toggleType(type)}
+                className="rounded border-gray-300"
+              />
+              <span className="text-sm capitalize">{type}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <div className="space-y-2">
+          <Label>Basement Levels</Label>
+          <Input
+            type="number"
+            value={data.basement_levels ?? ""}
+            onChange={(e) => update({ basement_levels: e.target.value ? Number(e.target.value) : null })}
+            placeholder="2"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label>Guest Parking</Label>
+          <label className="flex items-center gap-2 h-10 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={data.guest_parking}
+              onChange={(e) => update({ guest_parking: e.target.checked })}
+              className="rounded border-gray-300"
+            />
+            <span className="text-sm">Available</span>
+          </label>
+        </div>
+
+        <div className="space-y-2">
+          <Label>Per Unit Allotment</Label>
+          <Input
+            value={data.allotment || ""}
+            onChange={(e) => update({ allotment: e.target.value || null })}
+            placeholder="1 covered + 1 open per unit"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/properties/_components/PropertyForm.tsx
+++ b/src/app/admin/properties/_components/PropertyForm.tsx
@@ -11,13 +11,23 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ImageUploader } from "./ImageUploader";
 import { ConfigurationsEditor } from "./ConfigurationsEditor";
 import { AmenitiesSelector } from "./AmenitiesSelector";
+import { HighlightsEditor } from "./HighlightsEditor";
+import { SpecificationsEditor } from "./SpecificationsEditor";
+import { ParkingEditor } from "./ParkingEditor";
+import { TowersEditor } from "./TowersEditor";
+import { POIsEditor } from "./POIsEditor";
 import { propertyFormSchema, transformFormData, type PropertyFormValues, type PropertyFormData } from "./property-schema";
-import type { Configuration, ProjectImage } from "@/types/database";
+import type { Configuration, ProjectImage, ProjectHighlight, ProjectSpecification, ProjectParking, Tower, PointOfInterest, Icon } from "@/types/database";
 
 interface InitialData extends PropertyFormValues {
   images: Partial<ProjectImage>[];
   configurations: Partial<Configuration>[];
   amenityIds: string[];
+  highlights: ProjectHighlight[];
+  specifications: ProjectSpecification[];
+  parking: ProjectParking | null;
+  towers: Partial<Tower>[];
+  points_of_interest: PointOfInterest[];
 }
 
 interface PropertyFormProps {
@@ -26,6 +36,7 @@ interface PropertyFormProps {
   builders: { id: string; name: string }[];
   cities: string[];
   amenities: { id: string; name: string; category: string | null }[];
+  icons: Icon[];
   onSubmit: (data: PropertyFormData) => Promise<{ success: boolean; error?: string }>;
   onDelete?: () => Promise<{ success: boolean; error?: string }>;
 }
@@ -36,6 +47,7 @@ export function PropertyForm({
   builders,
   cities,
   amenities,
+  icons,
   onSubmit,
   onDelete,
 }: PropertyFormProps) {
@@ -47,6 +59,11 @@ export function PropertyForm({
   const [images, setImages] = useState<Partial<ProjectImage>[]>(initialData?.images || []);
   const [configurations, setConfigurations] = useState<Partial<Configuration>[]>(initialData?.configurations || []);
   const [amenityIds, setAmenityIds] = useState<string[]>(initialData?.amenityIds || []);
+  const [highlights, setHighlights] = useState<ProjectHighlight[]>(initialData?.highlights || []);
+  const [specifications, setSpecifications] = useState<ProjectSpecification[]>(initialData?.specifications || []);
+  const [parking, setParking] = useState<ProjectParking | null>(initialData?.parking || null);
+  const [towers, setTowers] = useState<Partial<Tower>[]>(initialData?.towers || []);
+  const [pois, setPois] = useState<PointOfInterest[]>(initialData?.points_of_interest || []);
 
   const form = useForm<PropertyFormValues>({
     resolver: zodResolver(propertyFormSchema),
@@ -54,6 +71,7 @@ export function PropertyForm({
       name: "",
       slug: "",
       description: "",
+      tagline: "",
       status: "upcoming",
       property_type: "",
       price_min: "",
@@ -77,7 +95,7 @@ export function PropertyForm({
   const handleSubmit = form.handleSubmit((data) => {
     setError(null);
     startTransition(async () => {
-      const fullData = transformFormData(data, images, configurations, amenityIds);
+      const fullData = transformFormData(data, images, configurations, amenityIds, highlights, specifications, parking, towers, pois);
       const result = await onSubmit(fullData);
       if (result.success) {
         router.push("/admin/properties");
@@ -134,6 +152,10 @@ export function PropertyForm({
           <div className="space-y-2 sm:col-span-2">
             <Label htmlFor="description">Description</Label>
             <textarea id="description" {...form.register("description")} rows={3} className="w-full px-3 py-2 border rounded-md bg-background" />
+          </div>
+          <div className="space-y-2 sm:col-span-2">
+            <Label htmlFor="tagline">Tagline</Label>
+            <Input id="tagline" {...form.register("tagline")} placeholder="Short marketing line, e.g., 'Gateway of Chandigarh'" maxLength={100} />
           </div>
           <div className="space-y-2">
             <Label htmlFor="status">Status *</Label>
@@ -245,7 +267,7 @@ export function PropertyForm({
           <CardTitle className="text-base">Configurations</CardTitle>
         </CardHeader>
         <CardContent>
-          <ConfigurationsEditor configurations={configurations} onChange={setConfigurations} />
+          <ConfigurationsEditor configurations={configurations} towers={towers} onChange={setConfigurations} />
         </CardContent>
       </Card>
 
@@ -256,6 +278,56 @@ export function PropertyForm({
         </CardHeader>
         <CardContent>
           <AmenitiesSelector allAmenities={amenities} selected={amenityIds} onChange={setAmenityIds} />
+        </CardContent>
+      </Card>
+
+      {/* Highlights */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Project Highlights</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <HighlightsEditor highlights={highlights} icons={icons} onChange={setHighlights} />
+        </CardContent>
+      </Card>
+
+      {/* Specifications */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Specifications</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <SpecificationsEditor specifications={specifications} icons={icons} onChange={setSpecifications} />
+        </CardContent>
+      </Card>
+
+      {/* Towers */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Towers</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <TowersEditor towers={towers} onChange={setTowers} />
+        </CardContent>
+      </Card>
+
+      {/* Parking */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Parking</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ParkingEditor parking={parking} onChange={setParking} />
+        </CardContent>
+      </Card>
+
+      {/* Points of Interest */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Points of Interest</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <POIsEditor pois={pois} onChange={setPois} />
         </CardContent>
       </Card>
 

--- a/src/app/admin/properties/_components/SpecificationsEditor.tsx
+++ b/src/app/admin/properties/_components/SpecificationsEditor.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { ProjectSpecification, Icon } from "@/types/database";
+
+interface SpecificationsEditorProps {
+  specifications: ProjectSpecification[];
+  icons: Icon[];
+  onChange: (specs: ProjectSpecification[]) => void;
+}
+
+export function SpecificationsEditor({ specifications, icons, onChange }: SpecificationsEditorProps) {
+  const addSpec = () => {
+    onChange([...specifications, { label: "", value: "", icon_id: null, icon_name: null }]);
+  };
+
+  const updateSpec = (index: number, field: keyof ProjectSpecification, value: string | null) => {
+    const updated = [...specifications];
+    updated[index] = { ...updated[index], [field]: value };
+    onChange(updated);
+  };
+
+  const setIcon = (index: number, iconId: string) => {
+    const icon = icons.find((i) => i.id === iconId);
+    const updated = [...specifications];
+    updated[index] = {
+      ...updated[index],
+      icon_id: iconId || null,
+      icon_name: icon?.lucide_name || null,
+    };
+    onChange(updated);
+  };
+
+  const removeSpec = (index: number) => {
+    const updated = [...specifications];
+    updated.splice(index, 1);
+    onChange(updated);
+  };
+
+  return (
+    <div className="space-y-4">
+      {specifications.map((spec, i) => (
+        <div key={i} className="p-4 border rounded-lg space-y-4 relative">
+          <button
+            type="button"
+            onClick={() => removeSpec(i)}
+            className="absolute top-2 right-2 p-1 text-muted-foreground hover:text-red-500 transition-colors"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="space-y-2">
+              <Label>Label</Label>
+              <Input
+                value={spec.label}
+                onChange={(e) => updateSpec(i, "label", e.target.value)}
+                placeholder="e.g., Flooring"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Value</Label>
+              <Input
+                value={spec.value}
+                onChange={(e) => updateSpec(i, "value", e.target.value)}
+                placeholder="e.g., Premium Vitrified Tiles"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Icon</Label>
+              <select
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                value={spec.icon_id || ""}
+                onChange={(e) => setIcon(i, e.target.value)}
+              >
+                <option value="">No icon</option>
+                {icons.map((icon) => (
+                  <option key={icon.id} value={icon.id}>
+                    {icon.name} ({icon.lucide_name})
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </div>
+      ))}
+
+      <Button type="button" variant="outline" onClick={addSpec}>
+        <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+        </svg>
+        Add Specification
+      </Button>
+    </div>
+  );
+}

--- a/src/app/admin/properties/_components/TowersEditor.tsx
+++ b/src/app/admin/properties/_components/TowersEditor.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { Tower } from "@/types/database";
+
+interface TowersEditorProps {
+  towers: Partial<Tower>[];
+  onChange: (towers: Partial<Tower>[]) => void;
+}
+
+export function TowersEditor({ towers, onChange }: TowersEditorProps) {
+  const addTower = () => {
+    onChange([
+      ...towers,
+      {
+        id: `temp-${Date.now()}`,
+        name: "",
+        floor_from: null,
+        floor_to: null,
+        units_per_floor: null,
+        lifts_count: null,
+        lift_type: null,
+        staircase_info: null,
+      },
+    ]);
+  };
+
+  const updateTower = (index: number, field: keyof Tower, value: any) => {
+    const updated = [...towers];
+    updated[index] = { ...updated[index], [field]: value };
+    onChange(updated);
+  };
+
+  const removeTower = (index: number) => {
+    const updated = [...towers];
+    updated.splice(index, 1);
+    onChange(updated);
+  };
+
+  return (
+    <div className="space-y-4">
+      {towers.map((tower, i) => (
+        <div key={tower.id || i} className="p-4 border rounded-lg space-y-4 relative">
+          <button
+            type="button"
+            onClick={() => removeTower(i)}
+            className="absolute top-2 right-2 p-1 text-muted-foreground hover:text-red-500 transition-colors"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="space-y-2">
+              <Label>Tower Name</Label>
+              <Input
+                value={tower.name || ""}
+                onChange={(e) => updateTower(i, "name", e.target.value)}
+                placeholder="e.g., Tower A"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Floor From</Label>
+              <Input
+                type="number"
+                value={tower.floor_from ?? ""}
+                onChange={(e) => updateTower(i, "floor_from", e.target.value ? Number(e.target.value) : null)}
+                placeholder="1"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Floor To</Label>
+              <Input
+                type="number"
+                value={tower.floor_to ?? ""}
+                onChange={(e) => updateTower(i, "floor_to", e.target.value ? Number(e.target.value) : null)}
+                placeholder="25"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Units Per Floor</Label>
+              <Input
+                type="number"
+                value={tower.units_per_floor ?? ""}
+                onChange={(e) => updateTower(i, "units_per_floor", e.target.value ? Number(e.target.value) : null)}
+                placeholder="4"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Lifts Count</Label>
+              <Input
+                type="number"
+                value={tower.lifts_count ?? ""}
+                onChange={(e) => updateTower(i, "lifts_count", e.target.value ? Number(e.target.value) : null)}
+                placeholder="2"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Lift Type</Label>
+              <select
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                value={tower.lift_type || ""}
+                onChange={(e) => updateTower(i, "lift_type", e.target.value || null)}
+              >
+                <option value="">Select type</option>
+                <option value="standard">Standard</option>
+                <option value="high-speed">High Speed</option>
+              </select>
+            </div>
+
+            <div className="space-y-2 sm:col-span-3">
+              <Label>Staircase Info</Label>
+              <Input
+                value={tower.staircase_info || ""}
+                onChange={(e) => updateTower(i, "staircase_info", e.target.value || null)}
+                placeholder="e.g., Double staircase"
+              />
+            </div>
+          </div>
+        </div>
+      ))}
+
+      <Button type="button" variant="outline" onClick={addTower}>
+        <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+        </svg>
+        Add Tower
+      </Button>
+    </div>
+  );
+}

--- a/src/app/admin/properties/_components/property-schema.ts
+++ b/src/app/admin/properties/_components/property-schema.ts
@@ -1,11 +1,12 @@
 import { z } from "zod";
-import type { Project, Configuration, ProjectImage } from "@/types/database";
+import type { Project, Configuration, ProjectImage, ProjectHighlight, ProjectSpecification, ProjectParking, Tower, PointOfInterest } from "@/types/database";
 
 // Form schema - all string inputs, transform in submit handler
 export const propertyFormSchema = z.object({
   name: z.string().min(3, "Name must be at least 3 characters"),
   slug: z.string().min(3, "Slug required").regex(/^[a-z0-9-]+$/, "Slug must be lowercase with hyphens"),
   description: z.string().optional(),
+  tagline: z.string().optional(),
   status: z.enum(["upcoming", "ongoing", "completed"]),
   property_type: z.enum(["apartment", "villa", "plot", "commercial", "penthouse", ""]),
   price_min: z.string(),
@@ -48,9 +49,15 @@ export interface PropertyFormData {
   rera_id?: string;
   builder_id: string | null;
   published: boolean;
+  tagline?: string;
   images: Partial<ProjectImage>[];
   configurations: Partial<Configuration>[];
   amenityIds: string[];
+  highlights: ProjectHighlight[];
+  specifications: ProjectSpecification[];
+  parking: ProjectParking | null;
+  towers: Partial<Tower>[];
+  points_of_interest: PointOfInterest[];
 }
 
 // Transform form values to proper types for submission
@@ -58,12 +65,18 @@ export function transformFormData(
   values: PropertyFormValues,
   images: Partial<ProjectImage>[],
   configurations: Partial<Configuration>[],
-  amenityIds: string[]
+  amenityIds: string[],
+  highlights: ProjectHighlight[],
+  specifications: ProjectSpecification[],
+  parking: ProjectParking | null,
+  towers: Partial<Tower>[],
+  points_of_interest: PointOfInterest[]
 ): PropertyFormData {
   return {
     name: values.name,
     slug: values.slug,
     description: values.description,
+    tagline: values.tagline,
     status: values.status,
     property_type: values.property_type === "" ? null : values.property_type,
     price_min: values.price_min === "" ? null : Number(values.price_min),
@@ -84,6 +97,11 @@ export function transformFormData(
     images,
     configurations,
     amenityIds,
+    highlights,
+    specifications,
+    parking,
+    towers,
+    points_of_interest,
   };
 }
 
@@ -92,11 +110,17 @@ export function projectToFormValues(project: Project): PropertyFormValues & {
   images: Partial<ProjectImage>[];
   configurations: Partial<Configuration>[];
   amenityIds: string[];
+  highlights: ProjectHighlight[];
+  specifications: ProjectSpecification[];
+  parking: ProjectParking | null;
+  towers: Partial<Tower>[];
+  points_of_interest: PointOfInterest[];
 } {
   return {
     name: project.name || "",
     slug: project.slug || "",
     description: project.description || "",
+    tagline: project.tagline || "",
     status: project.status || "upcoming",
     property_type: project.property_type || "",
     price_min: project.price_min?.toString() ?? "",
@@ -117,5 +141,10 @@ export function projectToFormValues(project: Project): PropertyFormValues & {
     images: project.images || [],
     configurations: project.configurations || [],
     amenityIds: project.amenities?.map((a) => a.id) || [],
+    highlights: project.highlights || [],
+    specifications: project.specifications || [],
+    parking: project.parking || null,
+    towers: project.towers || [],
+    points_of_interest: project.points_of_interest || [],
   };
 }

--- a/src/app/admin/properties/actions.ts
+++ b/src/app/admin/properties/actions.ts
@@ -46,6 +46,7 @@ export async function createPropertyAction(
         name: data.name,
         slug: data.slug,
         description: data.description || null,
+        tagline: data.tagline || null,
         status: data.status,
         property_type: data.property_type,
         price_min: data.price_min,
@@ -62,6 +63,10 @@ export async function createPropertyAction(
         rera_id: data.rera_id || null,
         builder_id: data.builder_id,
         published_at: data.published ? new Date().toISOString() : null,
+        highlights: data.highlights || [],
+        specifications: data.specifications || [],
+        parking: data.parking || null,
+        points_of_interest: data.points_of_interest || [],
       })
       .select("id")
       .single();
@@ -76,6 +81,27 @@ export async function createPropertyAction(
     }
 
     const projectId = project.id;
+
+    // Insert towers
+    if (data.towers.length > 0) {
+      const towersToInsert = data.towers.map((tower, index) => ({
+        project_id: projectId,
+        name: tower.name!,
+        floor_from: tower.floor_from ?? null,
+        floor_to: tower.floor_to ?? null,
+        units_per_floor: tower.units_per_floor ?? null,
+        lifts_count: tower.lifts_count ?? null,
+        lift_type: tower.lift_type || null,
+        staircase_info: tower.staircase_info || null,
+        sort_order: index,
+      }));
+
+      const { error: towersError } = await supabase
+        .from("towers")
+        .insert(towersToInsert);
+
+      if (towersError) console.error("Error inserting towers:", towersError);
+    }
 
     // Insert images
     if (data.images.length > 0) {
@@ -108,8 +134,15 @@ export async function createPropertyAction(
         config_name: config.config_name || null,
         carpet_area_sqft: config.carpet_area_sqft ?? null,
         built_up_area_sqft: config.built_up_area_sqft ?? null,
+        balcony_area_sqft: config.balcony_area_sqft ?? null,
+        covered_area_sqft: config.covered_area_sqft ?? null,
+        super_area_sqft: config.super_area_sqft ?? null,
         price: config.price ?? null,
         floor_plan_cloudinary_id: config.floor_plan_cloudinary_id || null,
+        tower_id: config.tower_id || null,
+        floor_from: config.floor_from ?? null,
+        floor_to: config.floor_to ?? null,
+        type_label: config.type_label || null,
       }));
 
       const { error: configsError } = await supabase
@@ -187,6 +220,7 @@ export async function updatePropertyAction(
         name: data.name,
         slug: data.slug,
         description: data.description || null,
+        tagline: data.tagline || null,
         status: data.status,
         property_type: data.property_type,
         price_min: data.price_min,
@@ -204,6 +238,10 @@ export async function updatePropertyAction(
         builder_id: data.builder_id,
         published_at,
         updated_at: new Date().toISOString(),
+        highlights: data.highlights || [],
+        specifications: data.specifications || [],
+        parking: data.parking || null,
+        points_of_interest: data.points_of_interest || [],
       })
       .eq("id", id);
 
@@ -239,6 +277,29 @@ export async function updatePropertyAction(
       }
     }
 
+    // Replace towers: delete existing, insert new
+    await supabase.from("towers").delete().eq("project_id", id);
+
+    if (data.towers.length > 0) {
+      const towersToInsert = data.towers.map((tower, index) => ({
+        project_id: id,
+        name: tower.name!,
+        floor_from: tower.floor_from ?? null,
+        floor_to: tower.floor_to ?? null,
+        units_per_floor: tower.units_per_floor ?? null,
+        lifts_count: tower.lifts_count ?? null,
+        lift_type: tower.lift_type || null,
+        staircase_info: tower.staircase_info || null,
+        sort_order: index,
+      }));
+
+      const { error: towersError } = await supabase
+        .from("towers")
+        .insert(towersToInsert);
+
+      if (towersError) console.error("Error inserting towers:", towersError);
+    }
+
     // Replace configurations: delete existing, insert new
     await supabase.from("configurations").delete().eq("project_id", id);
 
@@ -250,8 +311,15 @@ export async function updatePropertyAction(
         config_name: config.config_name || null,
         carpet_area_sqft: config.carpet_area_sqft ?? null,
         built_up_area_sqft: config.built_up_area_sqft ?? null,
+        balcony_area_sqft: config.balcony_area_sqft ?? null,
+        covered_area_sqft: config.covered_area_sqft ?? null,
+        super_area_sqft: config.super_area_sqft ?? null,
         price: config.price ?? null,
         floor_plan_cloudinary_id: config.floor_plan_cloudinary_id || null,
+        tower_id: config.tower_id || null,
+        floor_from: config.floor_from ?? null,
+        floor_to: config.floor_to ?? null,
+        type_label: config.type_label || null,
       }));
 
       const { error: configsError } = await supabase

--- a/src/app/admin/properties/new/page.tsx
+++ b/src/app/admin/properties/new/page.tsx
@@ -1,12 +1,14 @@
 import { getUniqueCities, getAllBuilders, getAllAmenities } from "@/lib/queries/admin";
+import { getIcons } from "@/lib/queries/projects";
 import { PropertyForm } from "../_components/PropertyForm";
 import { createPropertyAction } from "../actions";
 
 export default async function NewPropertyPage() {
-  const [cities, builders, amenities] = await Promise.all([
+  const [cities, builders, amenities, icons] = await Promise.all([
     getUniqueCities(),
     getAllBuilders(),
     getAllAmenities(),
+    getIcons(),
   ]);
 
   return (
@@ -19,6 +21,7 @@ export default async function NewPropertyPage() {
         builders={builders}
         cities={cities}
         amenities={amenities}
+        icons={icons}
         onSubmit={createPropertyAction}
       />
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -603,6 +603,16 @@
   animation: text-shine 3s linear infinite;
 }
 
+/* Hide scrollbar utility */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}
+
 /* Reduced motion support */
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -2,8 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Link from "next/link";
-import Image from "next/image";
-import { Menu, X, Building2, Map, Heart, User, LogOut } from "lucide-react";
+import { Menu, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { AnimatePresence, motion } from "framer-motion";
 
@@ -11,10 +10,14 @@ interface MobileNavProps {
   user: { email: string } | null;
 }
 
+const navLinks = [
+  { label: "Properties", path: "/properties" },
+  { label: "Map View", path: "/map" },
+];
+
 export function MobileNav({ user }: MobileNavProps) {
   const [isOpen, setIsOpen] = useState(false);
 
-  // Prevent body scroll when drawer is open
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = "hidden";
@@ -28,151 +31,111 @@ export function MobileNav({ user }: MobileNavProps) {
 
   const handleClose = () => setIsOpen(false);
 
-  const handleSignOut = async () => {
-    // Simulate sign out
-    handleClose();
-  };
-
   return (
     <div className="md:hidden">
       <Button
         variant="ghost"
-        size="sm"
+        size="icon"
         onClick={() => setIsOpen(true)}
-        className="group"
+        aria-label="Open menu"
+        className="h-10 w-10"
       >
-        <Menu className="w-6 h-6 transition-transform duration-200 group-hover:scale-110" />
+        <Menu className="w-6 h-6" />
       </Button>
 
       <AnimatePresence>
         {isOpen && (
-          <div className="fixed inset-0 z-50">
-            {/* Backdrop with fade animation */}
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.2 }}
-              className="absolute inset-0 bg-black/50 backdrop-blur-sm"
-              onClick={handleClose}
-            />
-
-            {/* Drawer with slide animation */}
-            <motion.div
-              initial={{ x: "100%" }}
-              animate={{ x: 0 }}
-              exit={{ x: "100%" }}
-              transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
-              className="absolute right-0 top-0 h-full w-72 bg-white shadow-2xl"
-            >
-            {/* Header */}
-            <div className="flex items-center justify-between p-4 border-b">
-              <Link
-                href="/"
-                className="flex items-center gap-2 group"
-                onClick={handleClose}
-              >
-                <Image src="/logo.png" alt="PerfectGhar.in" width={28} height={28} className="h-7 w-auto" />
-                <span className="font-bold">PerfectGhar.in</span>
-              </Link>
+          <motion.div
+            className="fixed inset-0 z-50 bg-background"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+          >
+            {/* Close button */}
+            <div className="flex justify-end p-4">
               <Button
                 variant="ghost"
-                size="sm"
+                size="icon"
                 onClick={handleClose}
-                className="group hover:bg-gray-100"
+                aria-label="Close menu"
+                className="h-10 w-10"
               >
-                <X className="w-5 h-5 transition-transform duration-200 group-hover:rotate-90" />
+                <X className="w-6 h-6" />
               </Button>
             </div>
 
-            {/* Navigation links with staggered entrance */}
-            <nav className="p-4 space-y-1">
-              <Link
-                href="/properties"
-                className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-100 transition-all duration-200 opacity-0 animate-bounce-in group"
-                style={{ animationDelay: "0.1s" }}
-                onClick={handleClose}
-              >
-                <Building2 className="w-5 h-5 text-gray-600 transition-transform duration-200 group-hover:scale-110" />
-                <span>Properties</span>
-              </Link>
-
-              <Link
-                href="/map"
-                className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-100 transition-all duration-200 opacity-0 animate-bounce-in group"
-                style={{ animationDelay: "0.15s" }}
-                onClick={handleClose}
-              >
-                <Map className="w-5 h-5 text-gray-600 transition-transform duration-200 group-hover:scale-110" />
-                <span>Map View</span>
-              </Link>
-
-              {user && (
-                <Link
-                  href="/saved"
-                  className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-100 transition-all duration-200 opacity-0 animate-bounce-in group"
-                  style={{ animationDelay: "0.2s" }}
-                  onClick={handleClose}
+            {/* Nav links */}
+            <nav className="flex flex-col px-8 pt-8">
+              {navLinks.map((link, i) => (
+                <motion.div
+                  key={link.path}
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.05 + i * 0.05, duration: 0.3 }}
                 >
-                  <Heart className="w-5 h-5 text-gray-600 transition-transform duration-200 group-hover:scale-110 group-hover:text-red-500" />
-                  <span>Saved</span>
-                </Link>
-              )}
-
-              <div
-                className="border-t my-4 opacity-0 animate-fade-in"
-                style={{ animationDelay: "0.25s" }}
-              />
-
-              {user ? (
-                <>
-                  <div
-                    className="flex items-center gap-3 p-3 opacity-0 animate-bounce-in"
-                    style={{ animationDelay: "0.3s" }}
-                  >
-                    <div className="w-8 h-8 rounded-full bg-blue-100 flex items-center justify-center">
-                      <User className="w-4 h-4 text-blue-600" />
-                    </div>
-                    <span className="text-sm text-gray-600 truncate">
-                      {user.email}
-                    </span>
-                  </div>
-                  <button
-                    onClick={handleSignOut}
-                    className="flex items-center gap-3 p-3 rounded-lg hover:bg-red-50 w-full text-left text-red-600 transition-all duration-200 opacity-0 animate-bounce-in group"
-                    style={{ animationDelay: "0.35s" }}
-                  >
-                    <LogOut className="w-5 h-5 transition-transform duration-200 group-hover:-translate-x-0.5" />
-                    <span>Sign out</span>
-                  </button>
-                </>
-              ) : (
-                <>
                   <Link
-                    href="/login"
-                    className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-100 transition-all duration-200 opacity-0 animate-bounce-in group"
-                    style={{ animationDelay: "0.3s" }}
+                    href={link.path}
+                    className="block py-4 font-display text-3xl font-semibold tracking-tight text-foreground transition-colors hover:text-primary"
                     onClick={handleClose}
                   >
-                    <User className="w-5 h-5 text-gray-600 transition-transform duration-200 group-hover:scale-110" />
-                    <span>Login</span>
+                    {link.label}
                   </Link>
-                  <div
-                    className="opacity-0 animate-bounce-in px-3 pt-2"
-                    style={{ animationDelay: "0.35s" }}
+                </motion.div>
+              ))}
+
+              {user && (
+                <motion.div
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.15, duration: 0.3 }}
+                >
+                  <Link
+                    href="/saved"
+                    className="block py-4 font-display text-3xl font-semibold tracking-tight text-foreground transition-colors hover:text-primary"
+                    onClick={handleClose}
                   >
+                    Saved
+                  </Link>
+                </motion.div>
+              )}
+            </nav>
+
+            {/* Bottom section — auth */}
+            <div className="absolute bottom-0 left-0 right-0 px-8 pb-10">
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.25, duration: 0.3 }}
+              >
+                {user ? (
+                  <div className="space-y-3">
+                    <p className="text-sm text-muted-foreground truncate">{user.email}</p>
+                    <Link
+                      href="/login"
+                      className="block text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+                      onClick={handleClose}
+                    >
+                      Sign out
+                    </Link>
+                  </div>
+                ) : (
+                  <div className="flex flex-col gap-3">
+                    <Link href="/login" onClick={handleClose}>
+                      <span className="text-lg font-medium text-muted-foreground transition-colors hover:text-foreground">
+                        Login
+                      </span>
+                    </Link>
                     <Link href="/signup" onClick={handleClose}>
-                      <Button className="w-full relative overflow-hidden group">
-                        <span className="relative z-10">Sign Up</span>
-                        <div className="absolute inset-0 -translate-x-full group-hover:translate-x-full transition-transform duration-700 bg-gradient-to-r from-transparent via-white/20 to-transparent" />
+                      <Button className="w-full h-12 text-base font-semibold">
+                        Sign Up
                       </Button>
                     </Link>
                   </div>
-                </>
-              )}
-            </nav>
-            </motion.div>
-          </div>
+                )}
+              </motion.div>
+            </div>
+          </motion.div>
         )}
       </AnimatePresence>
     </div>

--- a/src/components/property/FloorPlanLightbox.tsx
+++ b/src/components/property/FloorPlanLightbox.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface FloorPlanLightboxProps {
+  src: string;
+  alt: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function FloorPlanLightbox({ src, alt, open, onClose }: FloorPlanLightboxProps) {
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onClose]);
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          onClick={onClose}
+        >
+          <Button
+            variant="ghost"
+            size="sm"
+            className="absolute top-4 right-4 text-white hover:bg-white/20"
+            onClick={onClose}
+          >
+            <X className="w-6 h-6" />
+          </Button>
+          <motion.img
+            src={src}
+            alt={alt}
+            className="max-w-[90vw] max-h-[85vh] object-contain rounded-lg"
+            initial={{ scale: 0.9, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.9, opacity: 0 }}
+            transition={{ type: "spring", damping: 25, stiffness: 300 }}
+            onClick={(e) => e.stopPropagation()}
+          />
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/property/FloorPlanLightbox.tsx
+++ b/src/components/property/FloorPlanLightbox.tsx
@@ -15,18 +15,25 @@ interface FloorPlanLightboxProps {
 export function FloorPlanLightbox({ src, alt, open, onClose }: FloorPlanLightboxProps) {
   useEffect(() => {
     if (!open) return;
+    document.body.style.overflow = "hidden";
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     };
     document.addEventListener("keydown", handleKey);
-    return () => document.removeEventListener("keydown", handleKey);
+    return () => {
+      document.body.style.overflow = "";
+      document.removeEventListener("keydown", handleKey);
+    };
   }, [open, onClose]);
 
   return (
     <AnimatePresence>
       {open && (
         <motion.div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm pt-14"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Floor plan viewer"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
@@ -34,16 +41,18 @@ export function FloorPlanLightbox({ src, alt, open, onClose }: FloorPlanLightbox
         >
           <Button
             variant="ghost"
-            size="sm"
-            className="absolute top-4 right-4 text-white hover:bg-white/20"
+            size="icon"
+            autoFocus
+            className="absolute top-4 right-4 h-10 w-10 text-white hover:bg-white/20 rounded-full"
             onClick={onClose}
+            aria-label="Close floor plan"
           >
             <X className="w-6 h-6" />
           </Button>
           <motion.img
             src={src}
             alt={alt}
-            className="max-w-[90vw] max-h-[85vh] object-contain rounded-lg"
+            className="max-w-[90vw] max-h-[80vh] object-contain rounded-lg"
             initial={{ scale: 0.9, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
             exit={{ scale: 0.9, opacity: 0 }}

--- a/src/components/property/MobileCtaBar.tsx
+++ b/src/components/property/MobileCtaBar.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { MessageCircle, Calendar } from "lucide-react";
+
+interface MobileCtaBarProps {
+  propertyTitle: string;
+  phone?: string;
+  /** ID of the element to observe — bar shows when this element is not visible */
+  observeId: string;
+}
+
+export function MobileCtaBar({ propertyTitle, phone = "917719784712", observeId }: MobileCtaBarProps) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const el = document.getElementById(observeId);
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => setVisible(!entry.isIntersecting),
+      { threshold: 0 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [observeId]);
+
+  const waMessage = encodeURIComponent(`Hi, I'm interested in ${propertyTitle}.`);
+
+  return (
+    <div
+      className={`fixed bottom-0 left-0 right-0 z-40 lg:hidden border-t border-border bg-card px-4 py-3 transition-transform duration-300 ${
+        visible ? "translate-y-0" : "translate-y-full"
+      }`}
+    >
+      <div className="flex gap-3">
+        <a
+          href={`https://wa.me/${phone}?text=${waMessage}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-foreground px-4 py-3 text-sm font-semibold text-background transition-opacity hover:opacity-90"
+        >
+          <MessageCircle className="h-4 w-4" /> Talk to an Expert
+        </a>
+        <button className="flex flex-1 items-center justify-center gap-2 rounded-lg border border-border px-4 py-3 text-sm font-medium transition-colors hover:bg-muted">
+          <Calendar className="h-4 w-4" /> Schedule a visit
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/property/PointsOfInterest.tsx
+++ b/src/components/property/PointsOfInterest.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { MapPin } from "lucide-react";
+import type { PointOfInterest } from "@/types/database";
+
+interface PointsOfInterestProps {
+  pois: PointOfInterest[];
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  transport: "Transport",
+  education: "Education",
+  healthcare: "Healthcare",
+  shopping: "Shopping",
+  food: "Food & Dining",
+  lifestyle: "Lifestyle",
+  notable: "Notable",
+};
+
+export function PointsOfInterest({ pois }: PointsOfInterestProps) {
+  const categories = [...new Set(pois.map((p) => p.category))];
+  const [active, setActive] = useState<string>(categories[0] || "");
+
+  const filtered = active ? pois.filter((p) => p.category === active) : pois;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <MapPin className="w-5 h-5" />
+          Nearby Places
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {categories.length > 1 && (
+          <div className="flex flex-wrap gap-2 mb-4">
+            {categories.map((cat) => (
+              <button
+                key={cat}
+                type="button"
+                onClick={() => setActive(cat)}
+                className={`px-3 py-1.5 text-sm rounded-full border transition-colors ${
+                  active === cat
+                    ? "bg-primary text-primary-foreground border-primary"
+                    : "bg-white text-gray-600 border-gray-200 hover:border-gray-400"
+                }`}
+              >
+                {CATEGORY_LABELS[cat] || cat}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <div className="space-y-2">
+          {filtered.map((poi, i) => (
+            <div key={i} className="flex items-center justify-between py-2 border-b last:border-0">
+              <span className="text-gray-700">{poi.name}</span>
+              <span className="text-sm font-medium text-gray-500">
+                {poi.distance_value} {poi.distance_unit}
+              </span>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/property/PropertyCard.tsx
+++ b/src/components/property/PropertyCard.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useState } from "react";
 import { MapPin, Building2, Calendar, Home, Heart } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
-import { formatPriceRange, formatDate } from "@/lib/format";
+import { formatPrice, formatPriceRange, formatDate } from "@/lib/format";
 import { useFavorites } from "@/components/auth/FavoritesProvider";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { useRouter } from "next/navigation";
@@ -128,6 +128,9 @@ export function PropertyCard({ project, index = 0 }: PropertyCardProps) {
             <p className="text-lg font-semibold text-gray-900 transition-colors duration-200 group-hover:text-blue-600">
               {formatPriceRange(project.price_min, project.price_max, project.price_on_request)}
             </p>
+            {project.price_per_sqft && (
+              <p className="text-xs text-gray-500">{formatPrice(project.price_per_sqft)}/sqft</p>
+            )}
           </div>
 
           {/* Name with hover underline effect */}

--- a/src/components/property/QuickCtaSidebar.tsx
+++ b/src/components/property/QuickCtaSidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Phone, MessageCircle, Calendar, ShieldCheck, FileCheck, Building2 } from 'lucide-react';
+import { MessageCircle, Calendar, ShieldCheck, FileCheck, Building2 } from 'lucide-react';
 
 interface QuickCtaSidebarProps {
   projectId: string;
@@ -23,12 +23,6 @@ export function QuickCtaSidebar({ propertyTitle, price, specs, phone = '91771978
       )}
 
       <div className="space-y-2">
-        <a
-          href={`tel:+${phone}`}
-          className="flex w-full items-center justify-center gap-2 rounded-lg bg-gradient-gold px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90"
-        >
-          <Phone className="h-4 w-4" /> Call Now
-        </a>
         <a
           href={`https://wa.me/${phone}?text=${waMessage}`}
           target="_blank"

--- a/src/components/property/SortDropdown.tsx
+++ b/src/components/property/SortDropdown.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+const SORT_OPTIONS = [
+  { value: "", label: "Newest First" },
+  { value: "price_asc", label: "Price: Low to High" },
+  { value: "price_desc", label: "Price: High to Low" },
+  { value: "possession", label: "Possession Date" },
+];
+
+export function SortDropdown() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const current = searchParams.get("sort") || "";
+
+  const handleChange = (value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value) {
+      params.set("sort", value);
+    } else {
+      params.delete("sort");
+    }
+    router.push(`/properties?${params.toString()}`);
+  };
+
+  return (
+    <select
+      value={current}
+      onChange={(e) => handleChange(e.target.value)}
+      className="px-3 py-1.5 text-sm border rounded-md bg-white text-gray-700"
+    >
+      {SORT_OPTIONS.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/components/property/UnitShowcase.tsx
+++ b/src/components/property/UnitShowcase.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useState, useRef, useCallback, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { ChevronLeft, ChevronRight, BedDouble, Bath, Building2, Layers, Maximize } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { FloorPlanLightbox } from "./FloorPlanLightbox";
+import { formatArea, formatPriceRange } from "@/lib/format";
+import { getImageUrl } from "@/lib/image-urls";
+import type { Configuration, Tower } from "@/types/database";
+
+interface UnitShowcaseProps {
+  configurations: Configuration[];
+  towers?: Tower[];
+}
+
+function getConfigLabel(config: Configuration): string {
+  const name = config.config_name || (config.bedrooms ? `${config.bedrooms} BHK` : "Unit");
+  if (config.tower?.name) return `${name} — ${config.tower.name}`;
+  return name;
+}
+
+const slideVariants = {
+  enter: (direction: number) => ({
+    x: direction > 0 ? 200 : -200,
+    opacity: 0,
+  }),
+  center: { x: 0, opacity: 1 },
+  exit: (direction: number) => ({
+    x: direction > 0 ? -200 : 200,
+    opacity: 0,
+  }),
+};
+
+export function UnitShowcase({ configurations, towers }: UnitShowcaseProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [direction, setDirection] = useState(0);
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+  const pillsRef = useRef<HTMLDivElement>(null);
+
+  const config = configurations[activeIndex];
+  const tower = config?.tower || (config?.tower_id ? towers?.find((t) => t.id === config.tower_id) : undefined);
+  const showNav = configurations.length > 1;
+
+  const goTo = useCallback(
+    (index: number) => {
+      setDirection(index > activeIndex ? 1 : -1);
+      setActiveIndex(index);
+    },
+    [activeIndex]
+  );
+
+  const goNext = useCallback(() => {
+    if (activeIndex < configurations.length - 1) goTo(activeIndex + 1);
+  }, [activeIndex, configurations.length, goTo]);
+
+  const goPrev = useCallback(() => {
+    if (activeIndex > 0) goTo(activeIndex - 1);
+  }, [activeIndex, goTo]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "ArrowRight") goNext();
+      if (e.key === "ArrowLeft") goPrev();
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [goNext, goPrev]);
+
+  // Auto-scroll active pill into view
+  useEffect(() => {
+    if (!pillsRef.current) return;
+    const activePill = pillsRef.current.children[activeIndex] as HTMLElement;
+    if (activePill) {
+      activePill.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "center" });
+    }
+  }, [activeIndex]);
+
+  if (!configurations.length) return null;
+
+  const floorPlanSrc = config.floor_plan_cloudinary_id
+    ? getImageUrl(config.floor_plan_cloudinary_id, "card")
+    : null;
+  const floorPlanHero = config.floor_plan_cloudinary_id
+    ? getImageUrl(config.floor_plan_cloudinary_id, "hero")
+    : null;
+
+  // Collect specs that have data
+  const specs: { label: string; value: string }[] = [];
+  if (config.carpet_area_sqft) specs.push({ label: "Carpet", value: formatArea(config.carpet_area_sqft) });
+  if (config.super_area_sqft) specs.push({ label: "Super Area", value: formatArea(config.super_area_sqft) });
+  if (config.built_up_area_sqft) specs.push({ label: "Built-up", value: formatArea(config.built_up_area_sqft) });
+  if (config.balcony_area_sqft) specs.push({ label: "Balcony", value: formatArea(config.balcony_area_sqft) });
+  if (config.price) specs.push({ label: "Price", value: `₹${formatPriceRange(config.price, null, false)}` });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Layers className="w-5 h-5" />
+          Unit Plans & Configurations
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Pill Navigation */}
+        {showNav && (
+          <div ref={pillsRef} className="flex gap-2 overflow-x-auto pb-2 scrollbar-hide">
+            {configurations.map((c, i) => (
+              <button
+                key={c.id}
+                onClick={() => goTo(i)}
+                className={`shrink-0 rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+                  i === activeIndex
+                    ? "bg-gray-900 text-white"
+                    : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                }`}
+              >
+                {getConfigLabel(c)}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Carousel */}
+        <div className="relative overflow-hidden rounded-xl">
+          {/* Arrow buttons */}
+          {showNav && activeIndex > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="absolute left-2 top-1/2 -translate-y-1/2 z-10 bg-white/80 hover:bg-white shadow-md rounded-full h-9 w-9 p-0"
+              onClick={goPrev}
+            >
+              <ChevronLeft className="w-5 h-5" />
+            </Button>
+          )}
+          {showNav && activeIndex < configurations.length - 1 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="absolute right-2 top-1/2 -translate-y-1/2 z-10 bg-white/80 hover:bg-white shadow-md rounded-full h-9 w-9 p-0"
+              onClick={goNext}
+            >
+              <ChevronRight className="w-5 h-5" />
+            </Button>
+          )}
+
+          <AnimatePresence mode="wait" custom={direction}>
+            <motion.div
+              key={config.id}
+              custom={direction}
+              variants={slideVariants}
+              initial="enter"
+              animate="center"
+              exit="exit"
+              transition={{ duration: 0.3, ease: "easeInOut" }}
+              drag={showNav ? "x" : false}
+              dragConstraints={{ left: 0, right: 0 }}
+              dragElastic={0.1}
+              onDragEnd={(_, info) => {
+                if (info.offset.x < -50) goNext();
+                else if (info.offset.x > 50) goPrev();
+              }}
+            >
+              {/* Header bar */}
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-2 mb-4 px-1">
+                <h4 className="text-lg font-semibold">
+                  {config.config_name || (config.bedrooms ? `${config.bedrooms} BHK` : "Unit")}
+                </h4>
+                <div className="flex items-center gap-3 text-sm text-gray-500">
+                  {config.bedrooms != null && (
+                    <span className="flex items-center gap-1">
+                      <BedDouble className="w-4 h-4" /> {config.bedrooms}
+                    </span>
+                  )}
+                  {config.bathrooms != null && (
+                    <span className="flex items-center gap-1">
+                      <Bath className="w-4 h-4" /> {config.bathrooms}
+                    </span>
+                  )}
+                  {config.floor_from != null && config.floor_to != null && (
+                    <span>Floors {config.floor_from}–{config.floor_to}</span>
+                  )}
+                </div>
+                {tower && (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700">
+                    <Building2 className="w-3.5 h-3.5" />
+                    {tower.name}
+                    {tower.floor_from != null && tower.floor_to != null && (
+                      <span className="text-blue-500 ml-1">· {tower.floor_to - tower.floor_from + 1} floors</span>
+                    )}
+                  </span>
+                )}
+              </div>
+
+              {/* Floor Plan Image */}
+              {floorPlanSrc ? (
+                <button
+                  onClick={() => setLightboxOpen(true)}
+                  className="relative w-full group cursor-zoom-in"
+                >
+                  <img
+                    src={floorPlanSrc}
+                    alt={`Floor plan — ${getConfigLabel(config)}`}
+                    className="w-full rounded-lg object-contain bg-gray-50 border"
+                  />
+                  <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity bg-black/10 rounded-lg">
+                    <span className="flex items-center gap-1.5 bg-white/90 px-3 py-1.5 rounded-full text-sm font-medium shadow">
+                      <Maximize className="w-4 h-4" /> View Full Size
+                    </span>
+                  </div>
+                </button>
+              ) : (
+                <div className="w-full aspect-[4/3] rounded-lg bg-gray-50 border border-dashed border-gray-200 flex items-center justify-center">
+                  <p className="text-sm text-gray-400">Floor plan coming soon</p>
+                </div>
+              )}
+
+              {/* Specs bar */}
+              {specs.length > 0 && (
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-4 mt-4 px-1">
+                  {specs.map((s) => (
+                    <div key={s.label}>
+                      <p className="text-xs text-gray-500">{s.label}</p>
+                      <p className="text-sm font-semibold">{s.value}</p>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {/* Tower details (secondary info) */}
+              {tower && (tower.lifts_count || tower.staircase_info || tower.units_per_floor) && (
+                <div className="flex flex-wrap gap-x-4 gap-y-1 mt-3 px-1 text-xs text-gray-500">
+                  {tower.units_per_floor && <span>{tower.units_per_floor} units/floor</span>}
+                  {tower.lifts_count && (
+                    <span>
+                      {tower.lifts_count} {tower.lift_type || ""} lift{tower.lifts_count > 1 ? "s" : ""}
+                    </span>
+                  )}
+                  {tower.staircase_info && <span>{tower.staircase_info}</span>}
+                </div>
+              )}
+            </motion.div>
+          </AnimatePresence>
+        </div>
+
+        {/* Slide counter */}
+        {showNav && (
+          <p className="text-center text-xs text-gray-400">
+            {activeIndex + 1} / {configurations.length}
+          </p>
+        )}
+      </CardContent>
+
+      {/* Lightbox */}
+      {floorPlanHero && (
+        <FloorPlanLightbox
+          src={floorPlanHero}
+          alt={`Floor plan — ${getConfigLabel(config)}`}
+          open={lightboxOpen}
+          onClose={() => setLightboxOpen(false)}
+        />
+      )}
+    </Card>
+  );
+}

--- a/src/components/ui/DynamicIcon.tsx
+++ b/src/components/ui/DynamicIcon.tsx
@@ -1,0 +1,11 @@
+import { icons } from "lucide-react";
+
+interface DynamicIconProps extends React.SVGProps<SVGSVGElement> {
+  name: string;
+}
+
+export function DynamicIcon({ name, ...props }: DynamicIconProps) {
+  const Icon = icons[name as keyof typeof icons];
+  if (!Icon) return null;
+  return <Icon {...(props as any)} />;
+}

--- a/src/lib/queries/admin.ts
+++ b/src/lib/queries/admin.ts
@@ -192,7 +192,8 @@ export async function getProjectById(id: string): Promise<Project | null> {
       builder:builders(id, name),
       configurations(*),
       images:project_images(*),
-      amenities:project_amenities(amenity:amenities(*))
+      amenities:project_amenities(amenity:amenities(*)),
+      towers(*)
     `)
     .eq("id", id)
     .is("deleted_at", null)
@@ -206,6 +207,7 @@ export async function getProjectById(id: string): Promise<Project | null> {
   return {
     ...data,
     amenities: data.amenities?.map((pa: { amenity: unknown }) => pa.amenity) || [],
+    towers: data.towers || [],
   } as Project;
 }
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -12,6 +12,53 @@ export type InquiryStatus =
   | "closed"
   | "lost";
 
+export interface Icon {
+  id: string;
+  name: string;
+  lucide_name: string;
+  category: string | null;
+}
+
+export interface Tower {
+  id: string;
+  project_id: string;
+  name: string;
+  floor_from: number | null;
+  floor_to: number | null;
+  units_per_floor: number | null;
+  lifts_count: number | null;
+  lift_type: string | null;
+  staircase_info: string | null;
+  sort_order: number;
+}
+
+export interface ProjectHighlight {
+  text: string;
+  icon_id: string | null;
+  icon_name: string | null; // lucide_name, denormalized
+}
+
+export interface ProjectSpecification {
+  label: string;
+  value: string;
+  icon_id: string | null;
+  icon_name: string | null; // lucide_name, denormalized
+}
+
+export interface ProjectParking {
+  types: string[];
+  basement_levels: number | null;
+  guest_parking: boolean;
+  allotment: string | null;
+}
+
+export interface PointOfInterest {
+  name: string;
+  category: string;
+  distance_value: number;
+  distance_unit: string;
+}
+
 export interface Builder {
   id: string;
   name: string;
@@ -66,6 +113,11 @@ export interface Project {
     futureInfrastructureText?: string;
     developerTrackRecordSummary?: string;
   } | null;
+  tagline: string | null;
+  highlights: ProjectHighlight[];
+  specifications: ProjectSpecification[];
+  parking: ProjectParking | null;
+  points_of_interest: PointOfInterest[];
   created_at: string;
   updated_at: string;
   published_at: string | null;
@@ -75,6 +127,7 @@ export interface Project {
   configurations?: Configuration[];
   images?: ProjectImage[];
   amenities?: Amenity[];
+  towers?: Tower[];
 }
 
 export interface Configuration {
@@ -85,8 +138,17 @@ export interface Configuration {
   config_name: string | null;
   carpet_area_sqft: number | null;
   built_up_area_sqft: number | null;
+  balcony_area_sqft: number | null;
+  covered_area_sqft: number | null;
+  super_area_sqft: number | null;
   price: number | null;
   floor_plan_cloudinary_id: string | null;
+  tower_id: string | null;
+  floor_from: number | null;
+  floor_to: number | null;
+  type_label: string | null;
+  // Joined relation
+  tower?: Tower;
 }
 
 export interface ProjectImage {
@@ -167,6 +229,7 @@ export interface ProjectFilters {
   price_max?: number;
   builder_id?: string;
   search?: string;
+  sort?: "price_asc" | "price_desc" | "newest" | "possession";
 }
 
 // Map marker type (lightweight project data for map)

--- a/supabase/migrations/00012_icons_table.sql
+++ b/supabase/migrations/00012_icons_table.sql
@@ -1,0 +1,65 @@
+-- Icons table: reusable icon library for specs, highlights, etc.
+CREATE TABLE IF NOT EXISTS icons (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,              -- display name: "Flooring"
+  lucide_name TEXT NOT NULL,       -- lucide-react icon name: "layers"
+  category TEXT,                   -- grouping: "construction", "rooms", "general"
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- RLS: public read, admin write
+ALTER TABLE icons ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public can view icons"
+  ON icons FOR SELECT USING (true);
+
+CREATE POLICY "Admins can manage icons"
+  ON icons FOR ALL
+  USING (is_admin());
+
+-- Seed with real-estate-relevant Lucide icons
+INSERT INTO icons (name, lucide_name, category) VALUES
+  -- Construction & Materials
+  ('Flooring', 'layers', 'construction'),
+  ('Walls', 'square', 'construction'),
+  ('Paint', 'paintbrush', 'construction'),
+  ('Tiles', 'grid-3x3', 'construction'),
+  ('Cement', 'box', 'construction'),
+  ('Steel', 'shield', 'construction'),
+  ('Wood', 'tree-pine', 'construction'),
+  ('Glass', 'panel-top', 'construction'),
+  -- Rooms
+  ('Bedroom', 'bed-double', 'rooms'),
+  ('Bathroom', 'bath', 'rooms'),
+  ('Kitchen', 'cooking-pot', 'rooms'),
+  ('Living Room', 'sofa', 'rooms'),
+  ('Balcony', 'fence', 'rooms'),
+  ('Staircase', 'arrow-up-right', 'rooms'),
+  ('Parking', 'car', 'rooms'),
+  -- Fittings & Fixtures
+  ('Doors', 'door-open', 'fittings'),
+  ('Windows', 'app-window', 'fittings'),
+  ('Switches', 'toggle-right', 'fittings'),
+  ('Plumbing', 'droplets', 'fittings'),
+  ('Electrical', 'zap', 'fittings'),
+  ('AC', 'snowflake', 'fittings'),
+  ('Wardrobe', 'shirt', 'fittings'),
+  ('Chimney', 'wind', 'fittings'),
+  ('Sink', 'droplet', 'fittings'),
+  -- General
+  ('Elevator', 'arrow-up-down', 'general'),
+  ('Security', 'lock', 'general'),
+  ('Fire Safety', 'flame', 'general'),
+  ('Power', 'plug-zap', 'general'),
+  ('Water', 'waves', 'general'),
+  ('Garden', 'flower-2', 'general'),
+  ('View', 'eye', 'general'),
+  ('Location', 'map-pin', 'general'),
+  ('Quality', 'badge-check', 'general'),
+  ('Price', 'indian-rupee', 'general'),
+  ('Area', 'ruler', 'general'),
+  ('Building', 'building-2', 'general'),
+  ('Tower', 'building', 'general'),
+  ('Home', 'home', 'general'),
+  ('Star', 'star', 'general'),
+  ('Check', 'circle-check', 'general');

--- a/supabase/migrations/00013_project_new_fields.sql
+++ b/supabase/migrations/00013_project_new_fields.sql
@@ -1,0 +1,13 @@
+-- New project-level fields for Phase 1
+
+-- Tagline: short marketing line shown under project name
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS tagline TEXT;
+
+-- Highlights: ordered list of USPs [{text, icon_id, icon_name}]
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS highlights JSONB DEFAULT '[]'::jsonb;
+
+-- Specifications: key-value pairs with icons [{label, value, icon_id, icon_name}]
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS specifications JSONB DEFAULT '[]'::jsonb;
+
+-- Parking: structured parking info
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS parking JSONB;

--- a/supabase/migrations/00014_towers_table.sql
+++ b/supabase/migrations/00014_towers_table.sql
@@ -1,0 +1,38 @@
+-- Towers table: per-tower data for multi-tower projects
+CREATE TABLE IF NOT EXISTS towers (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,                -- "Tower A", "Wing B"
+  floor_from INT,                    -- starting floor number
+  floor_to INT,                      -- ending floor number
+  units_per_floor INT,               -- units on each floor
+  lifts_count INT,                   -- number of lifts
+  lift_type TEXT,                     -- "standard", "high-speed"
+  staircase_info TEXT,               -- e.g., "Double staircase"
+  sort_order INT DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_towers_project_id ON towers(project_id);
+
+-- RLS
+ALTER TABLE towers ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public can view towers"
+  ON towers FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM projects
+      WHERE projects.id = towers.project_id
+        AND projects.published_at IS NOT NULL
+        AND projects.deleted_at IS NULL
+    )
+  );
+
+CREATE POLICY "Admins can manage towers"
+  ON towers FOR ALL
+  USING (is_admin());
+
+-- Grant anon SELECT
+GRANT SELECT ON towers TO anon;
+GRANT ALL ON towers TO authenticated;

--- a/supabase/migrations/00015_configurations_extensions.sql
+++ b/supabase/migrations/00015_configurations_extensions.sql
@@ -1,0 +1,16 @@
+-- Extended area fields
+ALTER TABLE configurations ADD COLUMN IF NOT EXISTS balcony_area_sqft INT;
+ALTER TABLE configurations ADD COLUMN IF NOT EXISTS covered_area_sqft INT;
+ALTER TABLE configurations ADD COLUMN IF NOT EXISTS super_area_sqft INT;
+
+-- Tower association
+ALTER TABLE configurations ADD COLUMN IF NOT EXISTS tower_id UUID REFERENCES towers(id) ON DELETE SET NULL;
+
+-- Floor range
+ALTER TABLE configurations ADD COLUMN IF NOT EXISTS floor_from INT;
+ALTER TABLE configurations ADD COLUMN IF NOT EXISTS floor_to INT;
+
+-- Type label (e.g., "Type A", "Type B")
+ALTER TABLE configurations ADD COLUMN IF NOT EXISTS type_label TEXT;
+
+CREATE INDEX idx_configurations_tower_id ON configurations(tower_id);

--- a/supabase/migrations/00016_flexible_pois.sql
+++ b/supabase/migrations/00016_flexible_pois.sql
@@ -1,0 +1,4 @@
+-- Flexible points of interest array
+-- Example: [{"name": "Elante Mall", "category": "shopping", "distance_value": 5.5, "distance_unit": "km"}]
+-- Categories: transport, education, healthcare, shopping, food, lifestyle, notable
+ALTER TABLE projects ADD COLUMN IF NOT EXISTS points_of_interest JSONB DEFAULT '[]'::jsonb;

--- a/supabase/migrations/00017_seed_northview_homez.sql
+++ b/supabase/migrations/00017_seed_northview_homez.sql
@@ -1,0 +1,175 @@
+-- Seed: Northview Homez property listing
+-- Source: Northview Homez brochure (PBRERA-SAS79-PR0848)
+
+-- 1. Builder
+INSERT INTO builders (id, name, slug, description, website)
+VALUES (
+  'b0000001-0001-0001-0001-000000000001',
+  'KG Enterprises (Northview Group)',
+  'kg-enterprises-northview-group',
+  'KG Enterprises, operating under the Northview Group brand, is a real estate developer based in Zirakpur, Punjab. They specialize in ultra-luxury residential projects along the Ambala-Chandigarh National Highway corridor.',
+  'https://www.northviewhomez.com'
+)
+ON CONFLICT (slug) DO NOTHING;
+
+-- 2. Project
+INSERT INTO projects (
+  id, slug, name, description, tagline, status, property_type,
+  price_on_request, address, city, locality, pincode,
+  location,
+  total_units, available_units,
+  rera_id, builder_id,
+  vastu_compliant, gated_community,
+  meta_title, meta_description,
+  highlights, specifications, parking, points_of_interest,
+  project_details_extra, location_advantages,
+  published_at
+) VALUES (
+  'a0000001-0001-0001-0001-000000000002',
+  'northview-homez-zirakpur',
+  'Northview Homez',
+  'Northview Homez is an ultra-luxury residential project offering spacious 3BHK apartments and exclusive sky villas in Zirakpur, Punjab. Located directly on the Ambala-Chandigarh National Highway, the project features 4 towers built using advanced Mivan construction technology — ensuring earthquake resistance, uniform quality, and durability. With panoramic Shivalik Hills views, wide balconies, a grand gated entrance, exclusive clubhouse, and double basement parking, Northview Homez delivers a modern lifestyle where elegance meets convenience.',
+  'Gateway of Chandigarh',
+  'ongoing',
+  'apartment',
+  true,
+  'Ambala - Chandigarh National Highway, Zirakpur',
+  'Zirakpur',
+  'Ambala-Chandigarh Highway',
+  '140201',
+  ST_SetSRID(ST_MakePoint(76.8520, 30.6280), 4326)::geography,
+  157, 157,
+  'PBRERA-SAS79-PR0848',
+  'b0000001-0001-0001-0001-000000000001',
+  true,
+  true,
+  'Northview Homez - Ultra Luxury 3BHK & Sky Villas in Zirakpur | PerfectGhar.in',
+  'Ultra luxury 3BHK apartments and sky villas on Ambala-Chandigarh NH, Zirakpur. 4 towers, Mivan construction, Shivalik Hills view. RERA: PBRERA-SAS79-PR0848.',
+
+  -- highlights
+  '[
+    {"text": "145 Ultra Luxury 3BHK Flats", "icon_id": null, "icon_name": "building-2"},
+    {"text": "12 Ultra Luxury Sky-Villas", "icon_id": null, "icon_name": "building"},
+    {"text": "Exclusive Clubhouse", "icon_id": null, "icon_name": "home"},
+    {"text": "2 Flats per Floor in Tower A & B", "icon_id": null, "icon_name": "layers"},
+    {"text": "4 Flats per Floor in Tower C & D", "icon_id": null, "icon_name": "layers"},
+    {"text": "High Speed Lifts in Every Tower", "icon_id": null, "icon_name": "arrow-up-down"},
+    {"text": "Double Staircase in Each Tower", "icon_id": null, "icon_name": "arrow-up-right"},
+    {"text": "Every Apartment has the Widest Balcony", "icon_id": null, "icon_name": "fence"},
+    {"text": "Built with Advanced Mivan Technology", "icon_id": null, "icon_name": "shield"},
+    {"text": "Direct Entry from National Highway", "icon_id": null, "icon_name": "map-pin"},
+    {"text": "Perfect Shivalik Hills View", "icon_id": null, "icon_name": "eye"},
+    {"text": "Earthquake Resistant Construction", "icon_id": null, "icon_name": "badge-check"}
+  ]'::jsonb,
+
+  -- specifications (key-value with icon)
+  '[
+    {"label": "Living/Dining Flooring", "value": "Premium Quality Vitrified Tiles", "icon_id": null, "icon_name": "layers"},
+    {"label": "Doors", "value": "Laminated Flush Doors", "icon_id": null, "icon_name": "door-open"},
+    {"label": "Walls", "value": "Emulsion Paint", "icon_id": null, "icon_name": "paintbrush"},
+    {"label": "Windows", "value": "UPVC / CFFS PVC", "icon_id": null, "icon_name": "app-window"},
+    {"label": "Switches", "value": "Branded Modular Switches", "icon_id": null, "icon_name": "toggle-right"},
+    {"label": "Bedroom Wardrobes", "value": "Elegant Wardrobe of Best Quality", "icon_id": null, "icon_name": "shirt"},
+    {"label": "AC Provision", "value": "Split AC provision in Living & Bedrooms", "icon_id": null, "icon_name": "snowflake"},
+    {"label": "Washroom Flooring", "value": "Premium Vitrified / Anti-Skid Tiles", "icon_id": null, "icon_name": "grid-3x3"},
+    {"label": "Washroom Walls", "value": "Premium Wall Tiles (Full Ceiling Height)", "icon_id": null, "icon_name": "square"},
+    {"label": "CP Fittings", "value": "Jaquar / Kohler or Equivalent", "icon_id": null, "icon_name": "droplets"},
+    {"label": "Kitchen Sink", "value": "Branded Double Bowl Stainless Steel", "icon_id": null, "icon_name": "droplet"},
+    {"label": "Kitchen Walls", "value": "Premium Tiles 2ft above counter + Emulsion", "icon_id": null, "icon_name": "cooking-pot"},
+    {"label": "Balcony Flooring", "value": "Premium Quality Vitrified Tiles", "icon_id": null, "icon_name": "fence"},
+    {"label": "External Finish", "value": "Exterior Emulsion Weather Proof Paint", "icon_id": null, "icon_name": "paintbrush"},
+    {"label": "Plumbing", "value": "GI / CPVC / UPVC Internal Plumbing", "icon_id": null, "icon_name": "droplets"},
+    {"label": "Staircase Flooring", "value": "Granite / Premium Tiles", "icon_id": null, "icon_name": "arrow-up-right"},
+    {"label": "Connectivity", "value": "DTH & Broadband Provision", "icon_id": null, "icon_name": "zap"}
+  ]'::jsonb,
+
+  -- parking
+  '{"types": ["stilt", "basement"], "basement_levels": 2, "guest_parking": true, "allotment": null}'::jsonb,
+
+  -- points_of_interest
+  '[
+    {"name": "Chandigarh International Airport", "category": "transport", "distance_value": 10, "distance_unit": "min"},
+    {"name": "Chandigarh Railway Station", "category": "transport", "distance_value": 15, "distance_unit": "min"},
+    {"name": "Bus Stand", "category": "transport", "distance_value": 5, "distance_unit": "min"},
+    {"name": "Schools", "category": "education", "distance_value": 5, "distance_unit": "min"},
+    {"name": "Banks", "category": "notable", "distance_value": 2, "distance_unit": "min"},
+    {"name": "Hospitals", "category": "healthcare", "distance_value": 5, "distance_unit": "min"},
+    {"name": "Elante Mall", "category": "shopping", "distance_value": 15, "distance_unit": "min"},
+    {"name": "KFC / McDonald''s", "category": "food", "distance_value": 1, "distance_unit": "min"},
+    {"name": "D.Mart / Decathlon", "category": "shopping", "distance_value": 1, "distance_unit": "min"},
+    {"name": "Multiplex", "category": "lifestyle", "distance_value": 1, "distance_unit": "min"},
+    {"name": "Starbucks", "category": "food", "distance_value": 1, "distance_unit": "min"},
+    {"name": "St. Xavier''s International School", "category": "education", "distance_value": 3, "distance_unit": "min"},
+    {"name": "Alchemist Hospital", "category": "healthcare", "distance_value": 8, "distance_unit": "min"},
+    {"name": "IT City Mohali / Infosys", "category": "notable", "distance_value": 20, "distance_unit": "min"},
+    {"name": "Amity University", "category": "education", "distance_value": 15, "distance_unit": "min"},
+    {"name": "Chattbir Zoo", "category": "lifestyle", "distance_value": 10, "distance_unit": "min"}
+  ]'::jsonb,
+
+  -- project_details_extra
+  '{"totalTowers": 4, "totalUnits": 157, "floors": 14, "constructionStatus": "Under Construction (Mivan Technology)", "facingOptions": ["North", "South", "East", "West"]}'::jsonb,
+
+  -- location_advantages (legacy, keeping for backward compat)
+  '{"airportKm": 15, "schoolsKm": 2, "hospitalsKm": 3, "marketKm": 1}'::jsonb,
+
+  NOW()
+);
+
+-- 3. Towers
+INSERT INTO towers (id, project_id, name, floor_from, floor_to, units_per_floor, lifts_count, lift_type, staircase_info, sort_order)
+VALUES
+  ('c0000001-0001-0001-0001-000000000001', 'a0000001-0001-0001-0001-000000000002', 'Tower A', 1, 7, 2, 2, 'high-speed', 'Double staircase', 0),
+  ('c0000001-0001-0001-0001-000000000002', 'a0000001-0001-0001-0001-000000000002', 'Tower B', 1, 9, 2, 2, 'high-speed', 'Double staircase', 1),
+  ('c0000001-0001-0001-0001-000000000003', 'a0000001-0001-0001-0001-000000000002', 'Tower C', 2, 14, 4, 3, 'high-speed', 'Double staircase', 2),
+  ('c0000001-0001-0001-0001-000000000004', 'a0000001-0001-0001-0001-000000000002', 'Tower D', 2, 14, 4, 3, 'high-speed', 'Double staircase', 3);
+
+-- 4. Configurations (6 types from brochure)
+
+-- Type A: 3BHK with Store + Pooja Room — Tower A & B, Floors 1-7 / 1-9
+INSERT INTO configurations (project_id, config_name, bedrooms, bathrooms, carpet_area_sqft, balcony_area_sqft, covered_area_sqft, super_area_sqft, tower_id, floor_from, floor_to, type_label)
+VALUES
+  ('a0000001-0001-0001-0001-000000000002', '3 BHK + Store + Pooja Room', 3, 3, 1454, 470, 1924, 2400, 'c0000001-0001-0001-0001-000000000001', 1, 7, 'Type A'),
+  ('a0000001-0001-0001-0001-000000000002', '3 BHK + Store + Pooja Room', 3, 3, 1454, 470, 1924, 2400, 'c0000001-0001-0001-0001-000000000002', 1, 9, 'Type A');
+
+-- Type B: 3BHK with Pooja Room — Tower A
+INSERT INTO configurations (project_id, config_name, bedrooms, bathrooms, carpet_area_sqft, balcony_area_sqft, covered_area_sqft, super_area_sqft, tower_id, floor_from, floor_to, type_label)
+VALUES
+  ('a0000001-0001-0001-0001-000000000002', '3 BHK + Pooja Room', 3, 3, 1385, 470, 1855, 2310, 'c0000001-0001-0001-0001-000000000001', 1, 7, 'Type B');
+
+-- Type C: 3BHK with Pooja Room — Tower B
+INSERT INTO configurations (project_id, config_name, bedrooms, bathrooms, carpet_area_sqft, balcony_area_sqft, covered_area_sqft, super_area_sqft, tower_id, floor_from, floor_to, type_label)
+VALUES
+  ('a0000001-0001-0001-0001-000000000002', '3 BHK + Pooja Room', 3, 3, 1359, 460, 1819, 2255, 'c0000001-0001-0001-0001-000000000002', 1, 9, 'Type C');
+
+-- Type A (C&D): 3BHK with Store — Tower C & D
+INSERT INTO configurations (project_id, config_name, bedrooms, bathrooms, carpet_area_sqft, balcony_area_sqft, covered_area_sqft, super_area_sqft, tower_id, floor_from, floor_to, type_label)
+VALUES
+  ('a0000001-0001-0001-0001-000000000002', '3 BHK + Store', 3, 3, 1418, 348, 1767, 2050, 'c0000001-0001-0001-0001-000000000003', 2, 14, 'Type A'),
+  ('a0000001-0001-0001-0001-000000000002', '3 BHK + Store', 3, 3, 1418, 348, 1767, 2050, 'c0000001-0001-0001-0001-000000000004', 2, 14, 'Type A');
+
+-- Type B (C&D): 3BHK with Store — Tower C & D
+INSERT INTO configurations (project_id, config_name, bedrooms, bathrooms, carpet_area_sqft, balcony_area_sqft, covered_area_sqft, super_area_sqft, tower_id, floor_from, floor_to, type_label)
+VALUES
+  ('a0000001-0001-0001-0001-000000000002', '3 BHK + Store', 3, 3, 1374, 348, 1723, 1998, 'c0000001-0001-0001-0001-000000000003', 2, 14, 'Type B'),
+  ('a0000001-0001-0001-0001-000000000002', '3 BHK + Store', 3, 3, 1374, 348, 1723, 1998, 'c0000001-0001-0001-0001-000000000004', 2, 14, 'Type B');
+
+-- Type C (C&D): 3BHK Apartment — Tower C & D
+INSERT INTO configurations (project_id, config_name, bedrooms, bathrooms, carpet_area_sqft, balcony_area_sqft, covered_area_sqft, super_area_sqft, tower_id, floor_from, floor_to, type_label)
+VALUES
+  ('a0000001-0001-0001-0001-000000000002', '3 BHK Apartment', 3, 3, 1200, 467, 1667, 1910, 'c0000001-0001-0001-0001-000000000003', 2, 14, 'Type C'),
+  ('a0000001-0001-0001-0001-000000000002', '3 BHK Apartment', 3, 3, 1200, 467, 1667, 1910, 'c0000001-0001-0001-0001-000000000004', 2, 14, 'Type C');
+
+-- 5. Amenities (link existing amenities)
+INSERT INTO project_amenities (project_id, amenity_id)
+SELECT 'a0000001-0001-0001-0001-000000000002', id FROM amenities WHERE name IN (
+  'Clubhouse',
+  'Children''s Play Area',
+  'Garden',
+  'Parking',
+  '24/7 Security',
+  'CCTV',
+  'Power Backup',
+  'Lift',
+  'Fire Safety',
+  'Basketball Court'
+);


### PR DESCRIPTION
## Summary
- New admin editors for highlights, specs, parking, towers, POIs, configurations
- Seed Northview Homez property from brochure data
- UnitShowcase carousel replacing old Tower Details + Unit Configurations sections (framer-motion, pill nav, arrow nav, swipe, floor plan lightbox)
- Remove Call Now button, add floating mobile CTA bar (WhatsApp + Schedule a visit)
- Rewrite mobile nav — full-screen overlay with bold text links
- Sort dropdown, per-sqft price, dynamic icons on detail page
- Agent delegation instructions in AGENTS.md

## Test plan
- [ ] Verify property detail page renders UnitShowcase carousel with pill/arrow nav
- [ ] Test floor plan lightbox open/close (click, Escape, backdrop)
- [ ] Verify mobile CTA bar appears when InquiryForm scrolled out of view, hides on desktop
- [ ] Test mobile nav full-screen overlay opens/closes cleanly
- [ ] Verify admin editors (highlights, specs, towers, configs, POIs, parking) save correctly
- [ ] Run `npm run build` — passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)