### PR TITLE
fix: nav hover on transparent header

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -61,8 +61,10 @@ export function Header() {
             <Link
               key={link.path}
               href={link.path}
-              className={`text-sm font-medium transition-colors hover:text-primary ${
-                showSolid ? "text-foreground" : "text-white/90"
+              className={`text-sm font-medium transition-colors ${
+                showSolid
+                  ? "text-foreground hover:text-primary"
+                  : "text-white/90 hover:text-white"
               } ${pathname === link.path ? "text-primary" : ""}`}
             >
               {link.label}


### PR DESCRIPTION
## Summary
- Use `hover:text-white` on transparent header state instead of `hover:text-primary` which is invisible against the dark homepage background

## Test plan
- [ ] Homepage: hover over nav links — should brighten to white, not disappear
- [ ] Scroll down or visit /properties — hover should still use primary color on solid header

🤖 Generated with [Claude Code](https://claude.com/claude-code)